### PR TITLE
0.1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ name = "pushrod"
 path = "src/lib.rs"
 
 [dependencies]
-piston_window = "^0.89.0"
-find_folder = "^0.3.0"
+piston_window = "^0.89"
+find_folder = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 **Cross Platform UI Widget Library for Rust.**
 
-Draws inspiration from Atari GEM, TrollTech Qt, and others.
+Draws inspiration from lots of GUI libraries.
 
 [![Build Status](https://travis-ci.org/KenSuenobu/rust-pushrod.svg?branch=master)](https://travis-ci.org/KenSuenobu/rust-pushrod)
 [![](https://img.shields.io/crates/d/rust-pushrod.svg)](https://crates.io/crates/rust-pushrod)
+[![docs.rs for rust-pushrod](https://docs.rs/rust-pushrod/badge.svg)](https://docs.rs/rust-pushrod)
 
-Current state of the sample app:
+## (Ever Evolving) Screenshot of Sample
 
 [![](docs/sample-0.1.15.png)](docs/sample-0.1.15.png)
 
@@ -28,7 +29,7 @@ Pushrod requires the following minimum versions:
 
 | Library | Version |
 | ------- | ------- |
-| piston_window | 0.89.0 |
+| piston_window | 0.89 |
 | rust | 2018 |
 
 ## Runnable Examples

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# rust-pushrod
+
 [![Build Status](https://travis-ci.org/KenSuenobu/rust-pushrod.svg?branch=master)](https://travis-ci.org/KenSuenobu/rust-pushrod)
 [![](https://img.shields.io/crates/d/rust-pushrod.svg)](https://crates.io/crates/rust-pushrod)
 [![docs.rs for rust-pushrod](https://docs.rs/rust-pushrod/badge.svg)](https://docs.rs/rust-pushrod)
-
-# rust-pushrod
 
 **Cross Platform UI Widget Library for Rust.**
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
+[![Build Status](https://travis-ci.org/KenSuenobu/rust-pushrod.svg?branch=master)](https://travis-ci.org/KenSuenobu/rust-pushrod)
+[![](https://img.shields.io/crates/d/rust-pushrod.svg)](https://crates.io/crates/rust-pushrod)
+[![docs.rs for rust-pushrod](https://docs.rs/rust-pushrod/badge.svg)](https://docs.rs/rust-pushrod)
+
 # rust-pushrod
 
 **Cross Platform UI Widget Library for Rust.**
 
 Draws inspiration from lots of GUI libraries.
-
-[![Build Status](https://travis-ci.org/KenSuenobu/rust-pushrod.svg?branch=master)](https://travis-ci.org/KenSuenobu/rust-pushrod)
-[![](https://img.shields.io/crates/d/rust-pushrod.svg)](https://crates.io/crates/rust-pushrod)
-[![docs.rs for rust-pushrod](https://docs.rs/rust-pushrod/badge.svg)](https://docs.rs/rust-pushrod)
 
 ## (Ever Evolving) Screenshot of Sample
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 - Moved the context origin to 0x0 outside of the draw loop (#67)
 - Renamed BaseWidget to CanvasWidget (#27)
 - Removed autoclip config, as this will be automatic. (#20)
+- Context reset automatically takes place before each draw (#21)
 
 ## 0.1.15
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Pushrod Releases
 
+## 0.1.16
+
+- Keyboard events ticket (#43) completed by dannyfritz, merged to master.
+
 ## 0.1.15
 
 - Made a new `BlankCallback` type for timer

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 - Keyboard events ticket (#43) completed by dannyfritz, merged to master.
 - Modified code so that origin of drawing is 0x0 relative to the widget (#22)
+- Changed Cargo.toml to only use major version of Piston, minor releases are automatically used.
+- Updated README.
 
 ## 0.1.15
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 0.1.16
 
 - Keyboard events ticket (#43) completed by dannyfritz, merged to master.
+- Modified code so that origin of drawing is 0x0 relative to the widget (#22)
 
 ## 0.1.15
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 - Updated README.
 - Moved the context origin to 0x0 outside of the draw loop (#67)
 - Renamed BaseWidget to CanvasWidget (#27)
+- Removed autoclip config, as this will be automatic. (#20)
 
 ## 0.1.15
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Modified code so that origin of drawing is 0x0 relative to the widget (#22)
 - Changed Cargo.toml to only use major version of Piston, minor releases are automatically used.
 - Updated README.
+- Moved the context origin to 0x0 outside of the draw loop (#67)
 
 ## 0.1.15
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Changed Cargo.toml to only use major version of Piston, minor releases are automatically used.
 - Updated README.
 - Moved the context origin to 0x0 outside of the draw loop (#67)
+- Renamed BaseWidget to CanvasWidget (#27)
 
 ## 0.1.15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,17 +1,5 @@
 # rush-pushrod Roadmap
 
-## 0.1.x -> 0.2.0
-
-- [ ] Improvements
-  - [ ] Remove autoclip setting
-  - [ ] Automatically clip and modify context for widget drawing
-  - [ ] Auto reset context after drawing
-  - [ ] Treat drawing code as points from 0x0 instead of relative to screen
-- [ ] Implement Standard Widget Library (Extends from Base Widget)
-  - [ ] Text box (use Google Font Library, as it's the most uniform/generic)
-  - [ ] Button
-- [ ] More examples
-
 ## 0.1.x Accomplished
 
 - [x] Optimize main run loop

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,35 +42,17 @@
 ## 0.2.x -> 0.3.0
 
 - [ ] Complicated Widget Library
-  - [ ] Scrollbox (Horizontal and Vertical)
-  - [ ] Slider (Horizontal and Vertical)
   - [ ] Scrollable Viewing Area
-  - [ ] Toggle/Push Button
-  - [ ] Progress Indicator
-  - [ ] Popup Menu
   - [ ] Editable Text Box
-- [ ] Callbacks
-  - [ ] Implement for Mouse Click (Single click)
-  - [ ] Implement Double Click
-  - [ ] Implement Apple-like Mouse-up-inside
-  - [ ] Implement Apple-like Mouse-up-outside
-  - [ ] Create callbacks with a single option, contains event information instead of multiple callback types
 - [ ] Resource Manager
   - [ ] Store widgets in a centralized resource manager so that they can be (de)serialized to store
   - [ ] Allow for manipulation of widgets by ID through resource manager
   - [ ] Create dialog boxes (windows) with builder
-- [ ] Widget States
-  - [ ] Enabled/Disabled (disabled means no callback interactions from event loop)
-  - [ ] (In)visible (invisible means skip draw, remove from get_widget_id_for_point)
 - [ ] Widget/Run Loop Library Changes
-  - [ ] Implement visibility
   - [ ] Improve callbacks to use enum to define input parameters for each callback type
   - [ ] Implement enum for different `Widget` types.
 - [ ] Main loop
   - [ ] Object focus
-  - [ ] Window focus
-  - [ ] Window loses focus
-  - [ ] Window resize (needs to trigger a window-wide invalidate)
 
 ## TBD
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,8 @@
 
 ## 0.1.x -> 0.2.0
 
-- [ ] Widget/Run Loop Library Changes
-  - [ ] Change Widget object to be generic so that settings and calls are made against the widget (set as an enum)
-  - [ ] Change Widget to be a Struct<> to include widget generics for drawing and re-entrant functions
-  - [ ] Impl Widget<> should take generic widget and assign it internally so interactions are done against it as `widget.(x)`
-  - [ ] Ensure that the widget library code is still super simple and easy to understand
 - [ ] Improvements
+  - [ ] Remove autoclip setting
   - [ ] Automatically clip and modify context for widget drawing
   - [ ] Auto reset context after drawing
   - [ ] Treat drawing code as points from 0x0 instead of relative to screen

--- a/examples/clip.rs
+++ b/examples/clip.rs
@@ -1,0 +1,72 @@
+extern crate piston_window;
+extern crate find_folder;
+
+use piston_window::draw_state::Blend;
+use piston_window::*;
+
+fn main() {
+    println!("Press A to change blending");
+    println!("Press S to change clip inside/out");
+
+    let mut window: PistonWindow = WindowSettings::new(
+        "piston: draw_state",
+        [600, 600]
+    )
+        .exit_on_esc(true)
+        .samples(4)
+        .build()
+        .unwrap();
+
+    let assets = find_folder::Search::ParentsThenKids(3, 3)
+        .for_folder("assets").unwrap();
+    let blends = [Blend::Alpha, Blend::Add, Blend::Invert, Blend::Multiply];
+    let mut blend = 0;
+    let mut clip_inside = true;
+    let rust_logo = Texture::from_path(&mut window.factory,
+                                       assets.join("rust-512x512.jpg"),
+                                       Flip::None,
+                                       &TextureSettings::new()).unwrap();
+    window.set_lazy(true);
+    while let Some(e) = window.next() {
+        window.draw_2d(&e, |c, g| {
+            clear([0.8, 0.8, 0.8, 1.0], g);
+            g.clear_stencil(0);
+            Rectangle::new([1.0, 0.0, 0.0, 1.0])
+                .draw([0.0, 0.0, 100.0, 100.0], &c.draw_state, c.transform, g);
+
+            let draw_state = c.draw_state.blend(blends[blend]);
+            Rectangle::new([0.5, 1.0, 0.0, 0.3])
+                .draw([50.0, 50.0, 100.0, 100.0], &draw_state, c.transform, g);
+
+            let transform = c.transform.trans(100.0, 100.0);
+            // Compute clip rectangle from upper left corner.
+            let (clip_x, clip_y, clip_w, clip_h) = (100, 100, 100, 100);
+            let (clip_x, clip_y, clip_w, clip_h) =
+                (clip_x, c.viewport.unwrap().draw_size[1] - clip_y - clip_h, clip_w, clip_h);
+            let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
+            Image::new().draw(&rust_logo, &clipped, transform, g);
+
+            let transform = c.transform.trans(200.0, 200.0);
+            Ellipse::new([1.0, 0.0, 0.0, 1.0])
+                .draw([0.0, 0.0, 50.0, 50.0], &DrawState::new_clip(), transform, g);
+            Image::new().draw(&rust_logo,
+                              &if clip_inside { DrawState::new_inside() }
+                              else { DrawState::new_outside() },
+                              transform, g);
+        });
+
+        if let Some(Button::Keyboard(Key::A)) = e.press_args() {
+            blend = (blend + 1) % blends.len();
+            println!("Changed blending to {:?}", blend);
+        }
+
+        if let Some(Button::Keyboard(Key::S)) = e.press_args() {
+            clip_inside = !clip_inside;
+            if clip_inside {
+                println!("Changed to clip inside");
+            } else {
+                println!("Changed to clip outside");
+            }
+        }
+    }
+}

--- a/examples/clip.rs
+++ b/examples/clip.rs
@@ -1,5 +1,5 @@
-extern crate piston_window;
 extern crate find_folder;
+extern crate piston_window;
 
 use piston_window::draw_state::Blend;
 use piston_window::*;
@@ -8,51 +8,74 @@ fn main() {
     println!("Press A to change blending");
     println!("Press S to change clip inside/out");
 
-    let mut window: PistonWindow = WindowSettings::new(
-        "piston: draw_state",
-        [600, 600]
-    )
+    let mut window: PistonWindow = WindowSettings::new("piston: draw_state", [600, 600])
         .exit_on_esc(true)
         .samples(4)
         .build()
         .unwrap();
 
     let assets = find_folder::Search::ParentsThenKids(3, 3)
-        .for_folder("assets").unwrap();
+        .for_folder("assets")
+        .unwrap();
     let blends = [Blend::Alpha, Blend::Add, Blend::Invert, Blend::Multiply];
     let mut blend = 0;
     let mut clip_inside = true;
-    let rust_logo = Texture::from_path(&mut window.factory,
-                                       assets.join("rust-512x512.jpg"),
-                                       Flip::None,
-                                       &TextureSettings::new()).unwrap();
+    let rust_logo = Texture::from_path(
+        &mut window.factory,
+        assets.join("rust-512x512.jpg"),
+        Flip::None,
+        &TextureSettings::new(),
+    )
+    .unwrap();
     window.set_lazy(true);
     while let Some(e) = window.next() {
         window.draw_2d(&e, |c, g| {
             clear([0.8, 0.8, 0.8, 1.0], g);
             g.clear_stencil(0);
-            Rectangle::new([1.0, 0.0, 0.0, 1.0])
-                .draw([0.0, 0.0, 100.0, 100.0], &c.draw_state, c.transform, g);
+            Rectangle::new([1.0, 0.0, 0.0, 1.0]).draw(
+                [0.0, 0.0, 100.0, 100.0],
+                &c.draw_state,
+                c.transform,
+                g,
+            );
 
             let draw_state = c.draw_state.blend(blends[blend]);
-            Rectangle::new([0.5, 1.0, 0.0, 0.3])
-                .draw([50.0, 50.0, 100.0, 100.0], &draw_state, c.transform, g);
+            Rectangle::new([0.5, 1.0, 0.0, 0.3]).draw(
+                [50.0, 50.0, 100.0, 100.0],
+                &draw_state,
+                c.transform,
+                g,
+            );
 
             let transform = c.transform.trans(100.0, 100.0);
             // Compute clip rectangle from upper left corner.
             let (clip_x, clip_y, clip_w, clip_h) = (100, 100, 100, 100);
-            let (clip_x, clip_y, clip_w, clip_h) =
-                (clip_x, c.viewport.unwrap().draw_size[1] - clip_y - clip_h, clip_w, clip_h);
+            let (clip_x, clip_y, clip_w, clip_h) = (
+                clip_x,
+                c.viewport.unwrap().draw_size[1] - clip_y - clip_h,
+                clip_w,
+                clip_h,
+            );
             let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
             Image::new().draw(&rust_logo, &clipped, transform, g);
 
             let transform = c.transform.trans(200.0, 200.0);
-            Ellipse::new([1.0, 0.0, 0.0, 1.0])
-                .draw([0.0, 0.0, 50.0, 50.0], &DrawState::new_clip(), transform, g);
-            Image::new().draw(&rust_logo,
-                              &if clip_inside { DrawState::new_inside() }
-                              else { DrawState::new_outside() },
-                              transform, g);
+            Ellipse::new([1.0, 0.0, 0.0, 1.0]).draw(
+                [0.0, 0.0, 50.0, 50.0],
+                &DrawState::new_clip(),
+                transform,
+                g,
+            );
+            Image::new().draw(
+                &rust_logo,
+                &if clip_inside {
+                    DrawState::new_inside()
+                } else {
+                    DrawState::new_outside()
+                },
+                transform,
+                g,
+            );
         });
 
         if let Some(Button::Keyboard(Key::A)) = e.press_args() {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -18,9 +18,9 @@ extern crate pushrod;
 use piston_window::*;
 use pushrod::core::main::*;
 use pushrod::widget::box_widget::*;
+use pushrod::widget::image_widget::*;
 use pushrod::widget::text_widget::*;
 use pushrod::widget::timer_widget::*;
-use pushrod::widget::image_widget::*;
 use pushrod::widget::widget::*;
 
 fn main() {
@@ -32,17 +32,17 @@ fn main() {
     let factory: GfxFactory = window.factory.clone();
     let mut prod: Pushrod = Pushrod::new(window);
 
-//    let mut text_widget = TextWidget::new(
-//        factory,
-//        "OpenSans-Regular.ttf".to_string(),
-//        "Welcome to rust-pushrod!".to_string(),
-//        32,
-//    );
-//    text_widget.set_origin(14, 8);
-//    text_widget.set_size(400, 40);
-//    text_widget.set_color([0.75, 0.75, 1.0, 1.0]);
-//    text_widget.set_text_color([0.75, 0.25, 1.0, 1.0]);
-//    prod.widget_store.add_widget(Box::new(text_widget));
+    //    let mut text_widget = TextWidget::new(
+    //        factory,
+    //        "OpenSans-Regular.ttf".to_string(),
+    //        "Welcome to rust-pushrod!".to_string(),
+    //        32,
+    //    );
+    //    text_widget.set_origin(14, 8);
+    //    text_widget.set_size(400, 40);
+    //    text_widget.set_color([0.75, 0.75, 1.0, 1.0]);
+    //    text_widget.set_text_color([0.75, 0.25, 1.0, 1.0]);
+    //    prod.widget_store.add_widget(Box::new(text_widget));
 
     let mut base_widget = BaseWidget::new();
     base_widget.set_origin(50, 80);
@@ -92,10 +92,10 @@ fn main() {
     let mut timer = TimerWidget::new();
     timer.set_timeout(1000);
     timer.set_enabled(true);
-//    timer.on_timeout(Box::new(|| eprintln!("Timer.")));
+    //    timer.on_timeout(Box::new(|| eprintln!("Timer.")));
     prod.widget_store.add_widget(Box::new(timer));
 
-//    prod.add_event_listener_for_window(Box::new(ExampleListener::new()));
+    //    prod.add_event_listener_for_window(Box::new(ExampleListener::new()));
 
     // Runs the main event loop
     prod.run();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -44,7 +44,7 @@ fn main() {
     //    text_widget.set_text_color([0.75, 0.25, 1.0, 1.0]);
     //    prod.widget_store.add_widget(Box::new(text_widget));
 
-    let mut base_widget = BaseWidget::new();
+    let mut base_widget = CanvasWidget::new();
     base_widget.set_origin(50, 80);
     base_widget.set_size(200, 200);
     base_widget.set_color([0.5, 0.5, 0.5, 1.0]);

--- a/src/core/callbacks.rs
+++ b/src/core/callbacks.rs
@@ -53,15 +53,23 @@ pub type KeyCallback = Box<Fn(i32, Key, ButtonState) -> ()>;
 /// can be added to/extended as necessary.
 pub enum CallbackTypes {
     /// Callback that calls a function without any data.
-    BlankCallback { callback: BlankCallback },
+    BlankCallback {
+        callback: BlankCallback,
+    },
 
     /// Callback that only supplies its widget ID.
-    SingleCallback { callback: SingleCallback },
+    SingleCallback {
+        callback: SingleCallback,
+    },
 
     /// Callback that supplies its widget ID and a `Point` on the screen within the `Widget`.
-    PointCallback { callback: PointCallback },
+    PointCallback {
+        callback: PointCallback,
+    },
 
-    KeyCallback { callback: KeyCallback },
+    KeyCallback {
+        callback: KeyCallback,
+    },
 }
 
 /// This is the `CallbackStore` that is used to store a list of `CallbackTypes` that are

--- a/src/core/callbacks.rs
+++ b/src/core/callbacks.rs
@@ -105,9 +105,12 @@ impl CallbackStore {
         if self.callbacks.contains_key(&id) {
             &self.callbacks[&id]
         } else {
-            self.put(id, CallbackTypes::SingleCallback {
-                callback: Box::new(|_arg| { })
-            });
+            self.put(
+                id,
+                CallbackTypes::SingleCallback {
+                    callback: Box::new(|_arg| {}),
+                },
+            );
 
             &self.callbacks[&id]
         }

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -28,8 +28,8 @@ use piston_window::*;
 pub struct Pushrod {
     window: PistonWindow,
     pub widget_store: WidgetStore,
-//    event_listeners: RefCell<Vec<Box<EventListener>>>,
-//    event_list: RefCell<Vec<PushrodEvent>>,
+    //    event_listeners: RefCell<Vec<Box<EventListener>>>,
+    //    event_list: RefCell<Vec<PushrodEvent>>,
 }
 
 /// Pushrod implementation.  Create a `Pushrod::new( OpenGL )` object to create a new
@@ -57,8 +57,8 @@ impl Pushrod {
         Self {
             window,
             widget_store: WidgetStore::new(),
-//            event_listeners: RefCell::new(Vec::new()),
-//            event_list: RefCell::new(Vec::new()),
+            //            event_listeners: RefCell::new(Vec::new()),
+            //            event_list: RefCell::new(Vec::new()),
         }
     }
 
@@ -81,83 +81,83 @@ impl Pushrod {
     ///     prod.run();
     /// }
     /// ```
-//    pub fn add_event_listener_for_window(&self, _listener: Box<EventListener>) {
-//        //        self.event_listeners.borrow_mut().push(listener);
-//    }
-//
-//    /*
-//     * By handling events internally, we bypass the risk of the user having to interpret each
-//     * event, and having to figure out how to dispatch those events to any widgets that might be
-//     * in the display area.  Events will eventually be dispatched using a "dispatch all" method,
-//     * which will be done at the end of the event loop.  Any draw routines will be done within
-//     * the render_args() area, and a separate event will be sent out for that, as drawing
-//     * should be done at the end of all event processing, within the rendering loop, not the
-//     * updating loop (UPS vs. FPS)
-//     */
-//
-//    fn internal_handle_mouse_move(&self, _point: Point) {
-//        //        // Send the point movement to the widget event handler.
-//        //
-//        //        self.event_list
-//        //            .borrow_mut()
-//        //            .push(PushrodEvent::MouseEvent { point });
-//    }
-//
-//    fn internal_handle_mouse_button(&self, _button: ButtonArgs) {
-//        //        // Send the button click to the widget event handler.
-//        //
-//        //        if button.state == ButtonState::Press {
-//        //            match button.button {
-//        //                Button::Mouse(button) => {
-//        //                    self.event_list
-//        //                        .borrow_mut()
-//        //                        .push(PushrodEvent::MouseDownEvent { button });
-//        //                }
-//        //                _ => (),
-//        //            }
-//        //        } else if button.state == ButtonState::Release {
-//        //            match button.button {
-//        //                Button::Mouse(button) => {
-//        //                    self.event_list
-//        //                        .borrow_mut()
-//        //                        .push(PushrodEvent::MouseUpEvent { button });
-//        //                }
-//        //                _ => (),
-//        //            }
-//        //        }
-//    }
-//
-//    fn internal_handle_mouse_scroll(&self, _point: Point) {
-//        //        // Send the mouse scroll to the widget event handler.
-//        //
-//        //        self.event_list
-//        //            .borrow_mut()
-//        //            .push(PushrodEvent::MouseScrollEvent { point });
-//    }
-//
-//    fn internal_dispatch_events(&self) {
-//        //        for event in self.event_list.borrow_mut().iter() {
-//        //            for listener in self.event_listeners.borrow_mut().iter() {
-//        //                let event_mask = self.internal_derive_event_mask(event);
-//        //
-//        //                if listener.event_mask() & event_mask == event_mask {
-//        //                    listener.handle_event(event);
-//        //                }
-//        //            }
-//        //        }
-//        //
-//        //        self.event_list.borrow_mut().clear();
-//    }
-//
-//    fn internal_derive_event_mask(&self, _event: &PushrodEvent) -> EventMask {
-//        //        match event {
-//        //            PushrodEvent::MouseEvent { point: _ } => MASK_EVENT_MOUSE_MOVED,
-//        //            PushrodEvent::MouseDownEvent { button: _ } => MASK_EVENT_MOUSE_DOWN,
-//        //            PushrodEvent::MouseUpEvent { button: _ } => MASK_EVENT_MOUSE_UP,
-//        //            PushrodEvent::MouseScrollEvent { point: _ } => MASK_EVENT_MOUSE_SCROLL,
-//        //        }
-//        0
-//    }
+    //    pub fn add_event_listener_for_window(&self, _listener: Box<EventListener>) {
+    //        //        self.event_listeners.borrow_mut().push(listener);
+    //    }
+    //
+    //    /*
+    //     * By handling events internally, we bypass the risk of the user having to interpret each
+    //     * event, and having to figure out how to dispatch those events to any widgets that might be
+    //     * in the display area.  Events will eventually be dispatched using a "dispatch all" method,
+    //     * which will be done at the end of the event loop.  Any draw routines will be done within
+    //     * the render_args() area, and a separate event will be sent out for that, as drawing
+    //     * should be done at the end of all event processing, within the rendering loop, not the
+    //     * updating loop (UPS vs. FPS)
+    //     */
+    //
+    //    fn internal_handle_mouse_move(&self, _point: Point) {
+    //        //        // Send the point movement to the widget event handler.
+    //        //
+    //        //        self.event_list
+    //        //            .borrow_mut()
+    //        //            .push(PushrodEvent::MouseEvent { point });
+    //    }
+    //
+    //    fn internal_handle_mouse_button(&self, _button: ButtonArgs) {
+    //        //        // Send the button click to the widget event handler.
+    //        //
+    //        //        if button.state == ButtonState::Press {
+    //        //            match button.button {
+    //        //                Button::Mouse(button) => {
+    //        //                    self.event_list
+    //        //                        .borrow_mut()
+    //        //                        .push(PushrodEvent::MouseDownEvent { button });
+    //        //                }
+    //        //                _ => (),
+    //        //            }
+    //        //        } else if button.state == ButtonState::Release {
+    //        //            match button.button {
+    //        //                Button::Mouse(button) => {
+    //        //                    self.event_list
+    //        //                        .borrow_mut()
+    //        //                        .push(PushrodEvent::MouseUpEvent { button });
+    //        //                }
+    //        //                _ => (),
+    //        //            }
+    //        //        }
+    //    }
+    //
+    //    fn internal_handle_mouse_scroll(&self, _point: Point) {
+    //        //        // Send the mouse scroll to the widget event handler.
+    //        //
+    //        //        self.event_list
+    //        //            .borrow_mut()
+    //        //            .push(PushrodEvent::MouseScrollEvent { point });
+    //    }
+    //
+    //    fn internal_dispatch_events(&self) {
+    //        //        for event in self.event_list.borrow_mut().iter() {
+    //        //            for listener in self.event_listeners.borrow_mut().iter() {
+    //        //                let event_mask = self.internal_derive_event_mask(event);
+    //        //
+    //        //                if listener.event_mask() & event_mask == event_mask {
+    //        //                    listener.handle_event(event);
+    //        //                }
+    //        //            }
+    //        //        }
+    //        //
+    //        //        self.event_list.borrow_mut().clear();
+    //    }
+    //
+    //    fn internal_derive_event_mask(&self, _event: &PushrodEvent) -> EventMask {
+    //        //        match event {
+    //        //            PushrodEvent::MouseEvent { point: _ } => MASK_EVENT_MOUSE_MOVED,
+    //        //            PushrodEvent::MouseDownEvent { button: _ } => MASK_EVENT_MOUSE_DOWN,
+    //        //            PushrodEvent::MouseUpEvent { button: _ } => MASK_EVENT_MOUSE_UP,
+    //        //            PushrodEvent::MouseScrollEvent { point: _ } => MASK_EVENT_MOUSE_SCROLL,
+    //        //        }
+    //        0
+    //    }
 
     /// Retrieves the window `GfxFactory` factory object for graphics textures.
     pub fn get_factory(&mut self) -> &mut GfxFactory {
@@ -191,7 +191,7 @@ impl Pushrod {
     pub fn run(&mut self) {
         let mut last_widget_id = -1;
         let mut previous_mouse_position: Point = make_origin_point();
-//        let draw_size = self.window.draw_size();
+        //        let draw_size = self.window.draw_size();
 
         while let Some(ref event) = &self.window.next() {
             event.mouse_cursor(|x, y| {
@@ -208,7 +208,7 @@ impl Pushrod {
                     let current_parent_for_widget =
                         self.widget_store.get_parent_of(current_widget_id);
 
-//                    self.internal_handle_mouse_move(mouse_point.clone());
+                    //                    self.internal_handle_mouse_move(mouse_point.clone());
 
                     // Handles the mouse move callback.
                     if current_widget_id != -1 {
@@ -237,14 +237,14 @@ impl Pushrod {
                 }
             });
 
-//            event.button(|button| {
-//                self.internal_handle_mouse_button(button);
-//            });
+            //            event.button(|button| {
+            //                self.internal_handle_mouse_button(button);
+            //            });
 
             event.mouse_scroll(|x, y| {
                 let mouse_point = make_point_f64(x, y);
 
-//                self.internal_handle_mouse_scroll(mouse_point.clone());
+                //                self.internal_handle_mouse_scroll(mouse_point.clone());
 
                 if last_widget_id != -1 {
                     self.widget_store
@@ -257,7 +257,7 @@ impl Pushrod {
             });
 
             // Dispatch events here in the bus
-//            self.internal_dispatch_events();
+            //            self.internal_dispatch_events();
 
             // FPS loop handling
 

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -253,9 +253,14 @@ impl Pushrod {
             });
 
             match event {
-                Event::Input(Input::Button(ButtonArgs{state, button: Button::Keyboard(key), scancode})) => {
-                    self.widget_store.keypress_for_id(last_widget_id, &key, &state);
-                },
+                Event::Input(Input::Button(ButtonArgs {
+                    state,
+                    button: Button::Keyboard(key),
+                    scancode,
+                })) => {
+                    self.widget_store
+                        .keypress_for_id(last_widget_id, &key, &state);
+                }
                 _ => {}
             };
 

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -179,62 +179,21 @@ impl WidgetStore {
             let paint_widget = &mut self.widgets[paint_id as usize];
 
             if &paint_widget.widget.is_invalidated() == &true {
-//                // Implementation of auto-clipping.  Clips the object's drawing area.
-//                if paint_widget.widget.get_autoclip() {
-//                    let trans = c.transform.trans(
-//                        paint_widget.widget.get_origin().x as f64,
-//                        paint_widget.widget.get_origin().y as f64,
-//                    );
-//                    let viewport = c.viewport.unwrap();
-//                    let scale_x = viewport.draw_size[0] as f64 / viewport.window_size[0];
-//                    let scale_y = viewport.draw_size[1] as f64 / viewport.window_size[1];
-//
-//                    let clip_rect = [
-//                        ((paint_widget.widget.get_origin().x as f64 + viewport.rect[0] as f64)
-//                            * scale_x) as u32,
-//                        ((paint_widget.widget.get_origin().y as f64 + viewport.rect[1] as f64)
-//                            * scale_y) as u32,
-//                        (paint_widget.widget.get_size().w as f64 * scale_x) as u32,
-//                        (paint_widget.widget.get_size().h as f64 * scale_y) as u32,
-//                    ];
-//
-//                    let vp = Viewport {
-//                        rect: [
-//                            paint_widget.widget.get_origin().x as i32 + viewport.rect[0],
-//                            paint_widget.widget.get_origin().y as i32 + viewport.rect[1],
-//                            paint_widget.widget.get_size().w as i32,
-//                            paint_widget.widget.get_size().h as i32,
-//                        ],
-//                        draw_size: viewport.draw_size,
-//                        window_size: viewport.window_size,
-//                    };
-//
-//                    let clipped = Context {
-//                        viewport: Some(vp),
-//                        view: c.view,
-//                        transform: trans,
-//                        draw_state: c.draw_state.scissor(clip_rect),
-//                    };
-//
-//                    &paint_widget.widget.draw(clipped, g);
-//                } else {
-                    let origin: Point = paint_widget.widget.get_origin().clone();
+                let origin: Point = paint_widget.widget.get_origin().clone();
 
-                    c.reset();
+                c.reset();
 
-                    let new_context = Context {
-                        viewport: c.viewport,
-                        view: c.view,
-                        transform: c.transform.trans(origin.x as f64, origin.y as f64),
-                        draw_state: c.draw_state,
-                    };
+                let new_context = Context {
+                    viewport: c.viewport,
+                    view: c.view,
+                    transform: c.transform.trans(origin.x as f64, origin.y as f64),
+                    draw_state: c.draw_state,
+                };
 
-                    &paint_widget.widget.draw(new_context, g);
-//                }
+                &paint_widget.widget.draw(new_context, g);
             }
 
             if parents_of_widget[pos] != widget_id {
-                c.reset();
                 self.draw(paint_id, c, g);
             }
         }

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -199,6 +199,8 @@ impl WidgetStore {
         }
     }
 
+    /// Callback to `key_pressed` for a `Widget` by ID with its corresponding key, and button
+    /// state (pressed or released)
     pub fn keypress_for_id(&mut self, id: i32, key: &Key, state: &ButtonState) {
         &self.widgets[id as usize].widget.key_pressed(id, key, state);
     }

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -45,7 +45,7 @@ impl WidgetStore {
     /// Creates a new `WidgetStore`.
     pub fn new() -> Self {
         let mut widgets_list: Vec<WidgetContainer> = Vec::new();
-        let mut base_widget = BaseWidget::new();
+        let mut base_widget = CanvasWidget::new();
 
         base_widget.set_size(800, 600);
         widgets_list.push(WidgetContainer {

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -179,48 +179,58 @@ impl WidgetStore {
             let paint_widget = &mut self.widgets[paint_id as usize];
 
             if &paint_widget.widget.is_invalidated() == &true {
-                // Implementation of auto-clipping.  Clips the object's drawing area.
-                if paint_widget.widget.get_autoclip() {
-                    let trans = c.transform.trans(
-                        paint_widget.widget.get_origin().x as f64,
-                        paint_widget.widget.get_origin().y as f64,
-                    );
-                    let viewport = c.viewport.unwrap();
-                    let scale_x = viewport.draw_size[0] as f64 / viewport.window_size[0];
-                    let scale_y = viewport.draw_size[1] as f64 / viewport.window_size[1];
+//                // Implementation of auto-clipping.  Clips the object's drawing area.
+//                if paint_widget.widget.get_autoclip() {
+//                    let trans = c.transform.trans(
+//                        paint_widget.widget.get_origin().x as f64,
+//                        paint_widget.widget.get_origin().y as f64,
+//                    );
+//                    let viewport = c.viewport.unwrap();
+//                    let scale_x = viewport.draw_size[0] as f64 / viewport.window_size[0];
+//                    let scale_y = viewport.draw_size[1] as f64 / viewport.window_size[1];
+//
+//                    let clip_rect = [
+//                        ((paint_widget.widget.get_origin().x as f64 + viewport.rect[0] as f64)
+//                            * scale_x) as u32,
+//                        ((paint_widget.widget.get_origin().y as f64 + viewport.rect[1] as f64)
+//                            * scale_y) as u32,
+//                        (paint_widget.widget.get_size().w as f64 * scale_x) as u32,
+//                        (paint_widget.widget.get_size().h as f64 * scale_y) as u32,
+//                    ];
+//
+//                    let vp = Viewport {
+//                        rect: [
+//                            paint_widget.widget.get_origin().x as i32 + viewport.rect[0],
+//                            paint_widget.widget.get_origin().y as i32 + viewport.rect[1],
+//                            paint_widget.widget.get_size().w as i32,
+//                            paint_widget.widget.get_size().h as i32,
+//                        ],
+//                        draw_size: viewport.draw_size,
+//                        window_size: viewport.window_size,
+//                    };
+//
+//                    let clipped = Context {
+//                        viewport: Some(vp),
+//                        view: c.view,
+//                        transform: trans,
+//                        draw_state: c.draw_state.scissor(clip_rect),
+//                    };
+//
+//                    &paint_widget.widget.draw(clipped, g);
+//                } else {
+                    let origin: Point = paint_widget.widget.get_origin().clone();
 
-                    let clip_rect = [
-                        ((paint_widget.widget.get_origin().x as f64 + viewport.rect[0] as f64)
-                            * scale_x) as u32,
-                        ((paint_widget.widget.get_origin().y as f64 + viewport.rect[1] as f64)
-                            * scale_y) as u32,
-                        (paint_widget.widget.get_size().w as f64 * scale_x) as u32,
-                        (paint_widget.widget.get_size().h as f64 * scale_y) as u32,
-                    ];
-
-                    let vp = Viewport {
-                        rect: [
-                            paint_widget.widget.get_origin().x as i32 + viewport.rect[0],
-                            paint_widget.widget.get_origin().y as i32 + viewport.rect[1],
-                            paint_widget.widget.get_size().w as i32,
-                            paint_widget.widget.get_size().h as i32,
-                        ],
-                        draw_size: viewport.draw_size,
-                        window_size: viewport.window_size,
-                    };
-
-                    let clipped = Context {
-                        viewport: Some(vp),
-                        view: c.view,
-                        transform: trans,
-                        draw_state: c.draw_state.scissor(clip_rect),
-                    };
-
-                    &paint_widget.widget.draw(clipped, g);
-                } else {
                     c.reset();
-                    &paint_widget.widget.draw(c, g);
-                }
+
+                    let new_context = Context {
+                        viewport: c.viewport,
+                        view: c.view,
+                        transform: c.transform.trans(origin.x as f64, origin.y as f64),
+                        draw_state: c.draw_state,
+                    };
+
+                    &paint_widget.widget.draw(new_context, g);
+//                }
             }
 
             if parents_of_widget[pos] != widget_id {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,19 +15,23 @@
 //! Pushrod is a Cross Platform UI Widget Library for Rust.
 //!
 //! It is intended to be lightweight, easy to use, and easy to understand.  Pushrod draws
-//! inspiration from 16-bit GUI-based systems and other libraries over the years.
+//! inspiration from 16-bit GUI-based systems and other GUI libraries over the years.
 //!
-//! Pushrod uses Piston as its main window drawing and event loop functionality.  It utilizes
-//! piston2d-opengl graphics so that - eventually - the graphics can be represented as 3D
-//! poly objects with textures as canvases.  It also utilizes the `gfx_core` library for
-//! graphics functionality, as well as the `gfx_device_gl` support.
-//!
+//! # Dependencies
 //! Pushrod uses the following dependencies:
 //! ```ignore
 //! [dependencies]
 //! piston_window = "^0.89.0"
 //! find_folder = "^0.3.0"
 //! ```
+//!
+//! # Core Components
+//!
+//! # Callbacks
+//!
+//! # Events
+//!
+//! # Widgets
 
 /// Main module containing the run loop for the UI components, containers for windows and
 /// `Widget` trait objects, and so on.  Contains the core elements required to build
@@ -48,4 +52,5 @@ pub mod event;
 /// - Box Widget (for drawing a plain background with a box and a colored border)
 /// - Text Widget (for drawing text)
 /// - Timer Widget (for performing timer operations)
+/// - Image Widget (for drawing images)
 pub mod widget;

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -85,14 +85,13 @@ impl BoxWidget {
         let size: crate::core::point::Size = self.get_size();
         let border: f64 = self.get_border_thickness() as f64;
         let color: types::Color = self.get_border_color();
-        let draw_origin: math::Matrix2d = c.transform.trans(origin.x as f64, origin.y as f64);
 
         // Upper left to upper right
         line(
             color,
             border,
             [0.0 as f64, border, size.w as f64, border],
-            draw_origin,
+            c.transform,
             g,
         );
 
@@ -106,7 +105,7 @@ impl BoxWidget {
                 size.w as f64 - border,
                 size.h as f64,
             ],
-            draw_origin,
+            c.transform,
             g,
         );
 
@@ -115,7 +114,7 @@ impl BoxWidget {
             color,
             border,
             [border, border, border, size.h as f64],
-            draw_origin,
+            c.transform,
             g,
         );
 
@@ -129,7 +128,7 @@ impl BoxWidget {
                 size.w as f64,
                 size.h as f64 - border,
             ],
-            draw_origin,
+            c.transform,
             g,
         );
     }

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -91,12 +91,7 @@ impl BoxWidget {
         line(
             color,
             border,
-            [
-                0.0 as f64,
-                border,
-                size.w as f64,
-                border,
-            ],
+            [0.0 as f64, border, size.w as f64, border],
             draw_origin,
             g,
         );
@@ -119,12 +114,7 @@ impl BoxWidget {
         line(
             color,
             border,
-            [
-                border,
-                border,
-                border,
-                size.h as f64,
-            ],
+            [border, border, border, size.h as f64],
             draw_origin,
             g,
         );

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -85,18 +85,19 @@ impl BoxWidget {
         let size: crate::core::point::Size = self.get_size();
         let border: f64 = self.get_border_thickness() as f64;
         let color: types::Color = self.get_border_color();
+        let draw_origin: math::Matrix2d = c.transform.trans(origin.x as f64, origin.y as f64);
 
         // Upper left to upper right
         line(
             color,
             border,
             [
-                origin.x as f64,
-                origin.y as f64 + border,
-                (origin.x + size.w) as f64,
-                origin.y as f64 + border,
+                0.0 as f64,
+                border,
+                size.w as f64,
+                border,
             ],
-            c.transform,
+            draw_origin,
             g,
         );
 
@@ -105,12 +106,12 @@ impl BoxWidget {
             color,
             border,
             [
-                (origin.x + size.w) as f64 - border,
-                origin.y as f64 + border,
-                (origin.x + size.w) as f64 - border,
-                (origin.y + size.h) as f64,
+                size.w as f64 - border,
+                border,
+                size.w as f64 - border,
+                size.h as f64,
             ],
-            c.transform,
+            draw_origin,
             g,
         );
 
@@ -119,12 +120,12 @@ impl BoxWidget {
             color,
             border,
             [
-                origin.x as f64 + border,
-                origin.y as f64 + border,
-                origin.x as f64 + border,
-                (origin.y + size.h) as f64,
+                border,
+                border,
+                border,
+                size.h as f64,
             ],
-            c.transform,
+            draw_origin,
             g,
         );
 
@@ -133,12 +134,12 @@ impl BoxWidget {
             color,
             border,
             [
-                origin.x as f64,
-                (origin.y + size.h) as f64 - border,
-                (origin.x + size.w) as f64,
-                (origin.y + size.h) as f64 - border,
+                0.0 as f64,
+                size.h as f64 - border,
+                size.w as f64,
+                size.h as f64 - border,
             ],
-            c.transform,
+            draw_origin,
             g,
         );
     }

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -25,17 +25,17 @@ use crate::widget::widget::*;
 pub struct BoxWidget {
     config: Configurable,
     callbacks: CallbackStore,
-    base_widget: BaseWidget,
+    base_widget: CanvasWidget,
 }
 
-/// Implementation of the constructor for the `BaseWidget`.  Creates a new base widget
+/// Implementation of the constructor for the `CanvasWidget`.  Creates a new base widget
 /// that can be positioned anywhere on the screen.
 impl BoxWidget {
     pub fn new() -> Self {
         Self {
             config: Configurable::new(),
             callbacks: CallbackStore::new(),
-            base_widget: BaseWidget::new(),
+            base_widget: CanvasWidget::new(),
         }
     }
 
@@ -135,8 +135,8 @@ impl BoxWidget {
 }
 
 /// Implementation of the `BoxWidget` object with the `Widget` traits implemented.
-/// This implementation is similar to the `BaseWidget`, but incorporates a drawable box inside
-/// the widget.  Base widget is the `BaseWidget`.
+/// This implementation is similar to the `CanvasWidget`, but incorporates a drawable box inside
+/// the widget.  Base widget is the `CanvasWidget`.
 ///
 /// This is basically just a box with a fill color.  Use this to draw other things like buttons,
 /// text widgets, and so on, if you need anything with a drawable border.

--- a/src/widget/config.rs
+++ b/src/widget/config.rs
@@ -30,20 +30,17 @@ pub const CONFIG_ORIGIN: u8 = 1;
 /// Config entry key for retrieving the `Size` of the widget.
 pub const CONFIG_SIZE: u8 = 2;
 
-/// Config entry key for autoclipping the widget's drawing area.
-pub const CONFIG_AUTOCLIP: u8 = 3;
-
 /// Config entry key for retrieving the widget's color.
-pub const CONFIG_COLOR: u8 = 4;
+pub const CONFIG_COLOR: u8 = 3;
 
 /// Config entry key for retrieving the widget's border color.
-pub const CONFIG_COLOR_BORDER: u8 = 5;
+pub const CONFIG_COLOR_BORDER: u8 = 4;
 
 /// Config entry key for retrieving the widget's border width.
-pub const CONFIG_BORDER_WIDTH: u8 = 6;
+pub const CONFIG_BORDER_WIDTH: u8 = 5;
 
 /// Config entry key for retrieving the widget's text color.
-pub const CONFIG_TEXT_COLOR: u8 = 7;
+pub const CONFIG_TEXT_COLOR: u8 = 6;
 
 /// Enumeration data type containing storage areas for each configuration object.
 pub enum WidgetConfig {
@@ -55,10 +52,6 @@ pub enum WidgetConfig {
 
     /// `Size` of this widget.
     Size { size: crate::core::point::Size },
-
-    /// Indicates whether or not to automatically clip the drawing area to the bounds of the
-    /// widget.
-    Autoclip { clip: bool },
 
     /// The `types::Color` of this widget: `[f64; 4]` where the values are
     /// `[red, green, blue, transparency]`, values between 0 and 1.0.

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -111,9 +111,7 @@ impl Widget for ImageWidget {
         let size = self.get_size();
         let scale_w = (size.w as f64 / self.image_size.w as f64);
         let scale_h = (size.h as f64 / self.image_size.h as f64);
-        let transform = c
-            .transform
-            .scale(scale_w, scale_h);
+        let transform = c.transform.scale(scale_w, scale_h);
         let (clip_x, clip_y, clip_w, clip_h) = (0 as u32, 0 as u32, size.w as u32, size.h as u32);
         let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
 

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -116,8 +116,8 @@ impl Widget for ImageWidget {
             .trans(origin.x as f64, origin.y as f64)
             .scale(scale_w, scale_h);
         let (clip_x, clip_y, clip_w, clip_h) = (
-            origin.x as u32,
-            origin.y as u32,
+            0 as u32,
+            0 as u32,
             size.w as u32,
             size.h as u32,
         );

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -115,12 +115,7 @@ impl Widget for ImageWidget {
             .transform
             .trans(origin.x as f64, origin.y as f64)
             .scale(scale_w, scale_h);
-        let (clip_x, clip_y, clip_w, clip_h) = (
-            0 as u32,
-            0 as u32,
-            size.w as u32,
-            size.h as u32,
-        );
+        let (clip_x, clip_y, clip_w, clip_h) = (0 as u32, 0 as u32, size.w as u32, size.h as u32);
         let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
 
         image(&self.image, transform, g);

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -59,8 +59,8 @@ impl ImageWidget {
 }
 
 /// Implementation of the `BoxWidget` object with the `Widget` traits implemented.
-/// This implementation is similar to the `BaseWidget`, but incorporates a drawable box inside
-/// the widget.  Base widget is the `BaseWidget`.
+/// This implementation is similar to the `CanvasWidget`, but incorporates a drawable box inside
+/// the widget.  Base widget is the `CanvasWidget`.
 ///
 /// This is basically just a box with a fill color.  Use this to draw other things like buttons,
 /// text widgets, and so on, if you need anything with a drawable border.

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -113,7 +113,6 @@ impl Widget for ImageWidget {
         let scale_h = (size.h as f64 / self.image_size.h as f64);
         let transform = c
             .transform
-            .trans(origin.x as f64, origin.y as f64)
             .scale(scale_w, scale_h);
         let (clip_x, clip_y, clip_w, clip_h) = (0 as u32, 0 as u32, size.w as u32, size.h as u32);
         let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -42,14 +42,18 @@ impl ImageWidget {
             factory,
             &assets.join(image_name),
             Flip::None,
-            &TextureSettings::new()
-        ).unwrap();
+            &TextureSettings::new(),
+        )
+        .unwrap();
 
         Self {
             config: Configurable::new(),
             callbacks: CallbackStore::new(),
             image: texture.clone(),
-            image_size: crate::core::point::Size { w: texture.clone().get_size().0 as i32, h: texture.clone().get_size().1 as i32 },
+            image_size: crate::core::point::Size {
+                w: texture.clone().get_size().0 as i32,
+                h: texture.clone().get_size().1 as i32,
+            },
         }
     }
 }
@@ -107,19 +111,27 @@ impl Widget for ImageWidget {
         let size = self.get_size();
         let scale_w = (size.w as f64 / self.image_size.w as f64);
         let scale_h = (size.h as f64 / self.image_size.h as f64);
-        let transform = c.transform.trans(origin.x as f64, origin.y as f64).scale(scale_w, scale_h);
-        let (clip_x, clip_y, clip_w, clip_h) = (origin.x as u32, origin.y as u32, size.w as u32, size.h as u32);
+        let transform = c
+            .transform
+            .trans(origin.x as f64, origin.y as f64)
+            .scale(scale_w, scale_h);
+        let (clip_x, clip_y, clip_w, clip_h) = (
+            origin.x as u32,
+            origin.y as u32,
+            size.w as u32,
+            size.h as u32,
+        );
         let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
 
         image(&self.image, transform, g);
 
-//        let transform = c.transform.trans((origin.x * 2) as f64, (origin.y * 2) as f64).scale(0.50, 0.50);
-//
-//        // Compute clip rectangle from upper left corner.
-//        let (clip_x, clip_y, clip_w, clip_h) = ((origin.x * 2) as u32, (origin.y * 2) as u32, (size.w * 2) as u32, (size.h * 2) as u32);
-//        let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
-//
-//        Image::new().draw(&self.image, &clipped, transform, g);
+        //        let transform = c.transform.trans((origin.x * 2) as f64, (origin.y * 2) as f64).scale(0.50, 0.50);
+        //
+        //        // Compute clip rectangle from upper left corner.
+        //        let (clip_x, clip_y, clip_w, clip_h) = ((origin.x * 2) as u32, (origin.y * 2) as u32, (size.w * 2) as u32, (size.h * 2) as u32);
+        //        let clipped = c.draw_state.scissor([clip_x, clip_y, clip_w, clip_h]);
+        //
+        //        Image::new().draw(&self.image, &clipped, transform, g);
 
         // Then clear invalidation.
         self.clear_invalidate();

--- a/src/widget/text_widget.rs
+++ b/src/widget/text_widget.rs
@@ -96,8 +96,8 @@ impl TextWidget {
 }
 
 /// Implementation of the `BoxWidget` object with the `Widget` traits implemented.
-/// This implementation is similar to the `BaseWidget`, but incorporates a drawable box inside
-/// the widget.  Base widget is the `BaseWidget`.
+/// This implementation is similar to the `CanvasWidget`, but incorporates a drawable box inside
+/// the widget.  Base widget is the `CanvasWidget`.
 ///
 /// This is basically just a box with a fill color.  Use this to draw other things like buttons,
 /// text widgets, and so on, if you need anything with a drawable border.

--- a/src/widget/text_widget.rs
+++ b/src/widget/text_widget.rs
@@ -82,16 +82,13 @@ impl TextWidget {
         clear([1.0; 4], g);
 
         let origin: Point = self.get_origin();
-        let transform = c
-            .transform
-            .trans(origin.x as f64, origin.y as f64 + self.get_size().h as f64);
 
         text(
             self.get_text_color(),
             self.font_size,
             &self.text,
             &mut self.font_cache,
-            transform,
+            c.transform,
             g,
         )
         .unwrap();

--- a/src/widget/timer_widget.rs
+++ b/src/widget/timer_widget.rs
@@ -89,10 +89,8 @@ impl TimerWidget {
     /// Sets the closure function for the timer when a timeout has been triggered.  This closure
     /// needs to be `Boxed`.
     pub fn on_timeout(&mut self, callback: BlankCallback) {
-        self.callbacks().put(
-            CALLBACK_TIMER,
-            CallbackTypes::BlankCallback { callback },
-        );
+        self.callbacks()
+            .put(CALLBACK_TIMER, CallbackTypes::BlankCallback { callback });
     }
 
     /// Calls the timeout function.

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -206,6 +206,9 @@ pub trait Widget {
     }
 
     // Callback Triggers
+
+    /// Called when a keyboard event takes place within the bounds of a widget.  Includes the widget
+    /// ID, the key code that was affected, and its state - pressed or released.
     fn key_pressed(&mut self, widget_id: i32, key: &Key, state: &ButtonState) {
         self.perform_key_callback(CALLBACK_KEY_PRESSED, widget_id, key.clone(), state.clone());
     }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -29,7 +29,7 @@ use crate::widget::config::*;
 /// You _should_ override `draw`, but you are not required to.  (If you don't, however, your
 /// widget won't really do much.)
 ///
-/// If you want a blank base widget, refer to the `BaseWidget`, which will create a
+/// If you want a blank base widget, refer to the `CanvasWidget`, which will create a
 /// base widget that paints the contents of its bounds with whatever color has been
 /// specified with `set_color`.
 pub trait Widget {
@@ -312,16 +312,16 @@ pub trait Widget {
     }
 }
 
-/// This is the `BaseWidget`, which contains a top-level widget for display.  It does
+/// This is the `CanvasWidget`, which contains a top-level widget for display.  It does
 /// not contain any special logic other than being a base for a display layer.
-pub struct BaseWidget {
+pub struct CanvasWidget {
     config: Configurable,
     callbacks: CallbackStore,
 }
 
-/// Implementation of the constructor for the `PushrodBaseWidget`.  Creates a new base widget
+/// Implementation of the constructor for the `CanvasWidget`.  Creates a new base widget
 /// that can be positioned anywhere on the screen.
-impl BaseWidget {
+impl CanvasWidget {
     pub fn new() -> Self {
         Self {
             config: Configurable::new(),
@@ -330,7 +330,7 @@ impl BaseWidget {
     }
 }
 
-/// Implementation of the `BaseWidget` object with the `Widget` traits implemented.
+/// Implementation of the `CanvasWidget` object with the `Widget` traits implemented.
 /// This function only implements `config` and `callbacks`, which are used as a base for
 /// all `Widget`s.
 ///
@@ -347,7 +347,7 @@ impl BaseWidget {
 /// #           .build()
 /// #           .unwrap_or_else(|error| panic!("Failed to build PistonWindow: {}", error)));
 /// #
-///    let mut base_widget = BaseWidget::new();
+///    let mut base_widget = CanvasWidget::new();
 ///
 ///    base_widget.set_origin(100, 100);
 ///    base_widget.set_size(200, 200);
@@ -358,7 +358,7 @@ impl BaseWidget {
 ///
 ///    eprintln!("Added widget: ID={}", widget_id);
 ///
-///    let mut base_widget_2 = BaseWidget::new();
+///    let mut base_widget_2 = CanvasWidget::new();
 ///
 ///    base_widget_2.set_origin(125, 125);
 ///    base_widget_2.set_size(100, 100);
@@ -368,7 +368,7 @@ impl BaseWidget {
 ///    let widget_id_2 = prod.widget_store.add_widget_to_parent(Box::new(base_widget_2), widget_id);
 /// # }
 /// ```
-impl Widget for BaseWidget {
+impl Widget for CanvasWidget {
     fn config(&mut self) -> &mut Configurable {
         &mut self.config
     }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -206,9 +206,17 @@ pub trait Widget {
         }
     }
 
-    fn perform_key_callback(&mut self, callback_id: u32, widget_id: i32, key: Key, state: ButtonState) {
+    fn perform_key_callback(
+        &mut self,
+        callback_id: u32,
+        widget_id: i32,
+        key: Key,
+        state: ButtonState,
+    ) {
         match self.callbacks().get(callback_id) {
-            CallbackTypes::KeyCallback { callback } => callback(widget_id, key.clone(), state.clone()),
+            CallbackTypes::KeyCallback { callback } => {
+                callback(widget_id, key.clone(), state.clone())
+            }
             _ => (),
         }
     }
@@ -296,12 +304,7 @@ pub trait Widget {
 
         rectangle(
             self.get_color(),
-            [
-                0.0 as f64,
-                0.0 as f64,
-                size.w as f64,
-                size.h as f64,
-            ],
+            [0.0 as f64, 0.0 as f64, size.w as f64, size.h as f64],
             draw_origin,
             g,
         );

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -300,12 +300,11 @@ pub trait Widget {
     fn draw(&mut self, c: Context, g: &mut G2d) {
         let origin: Point = self.get_origin();
         let size: crate::core::point::Size = self.get_size();
-        let draw_origin: math::Matrix2d = c.transform.trans(origin.x as f64, origin.y as f64);
 
         rectangle(
             self.get_color(),
             [0.0 as f64, 0.0 as f64, size.w as f64, size.h as f64],
-            draw_origin,
+            c.transform,
             g,
         );
 

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -168,22 +168,6 @@ pub trait Widget {
         }
     }
 
-    /// Indicates to the underlying drawing mechanism as to whether or not this `Widget` needs to
-    /// have drawing clipping automatically applied.
-    fn set_autoclip(&mut self, clip: bool) {
-        self.config()
-            .set(CONFIG_AUTOCLIP, WidgetConfig::Autoclip { clip });
-        self.invalidate();
-    }
-
-    /// Retrieves the auto clip flag.
-    fn get_autoclip(&mut self) -> bool {
-        match self.config().get(CONFIG_AUTOCLIP) {
-            Some(WidgetConfig::Autoclip { ref clip }) => clip.clone(),
-            _ => false,
-        }
-    }
-
     // Callbacks
 
     /// Performs a callback stored in the `CallbackStore` for this `Widget`, but only for the

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -292,16 +292,17 @@ pub trait Widget {
     fn draw(&mut self, c: Context, g: &mut G2d) {
         let origin: Point = self.get_origin();
         let size: crate::core::point::Size = self.get_size();
+        let draw_origin: math::Matrix2d = c.transform.trans(origin.x as f64, origin.y as f64);
 
         rectangle(
             self.get_color(),
             [
-                origin.x as f64,
-                origin.y as f64,
+                0.0 as f64,
+                0.0 as f64,
                 size.w as f64,
                 size.h as f64,
             ],
-            c.transform,
+            draw_origin,
             g,
         );
 


### PR DESCRIPTION
Contains these changes:

- Keyboard events ticket (#43) completed by dannyfritz, merged to master.
- Modified code so that origin of drawing is 0x0 relative to the widget (#22)
- Changed Cargo.toml to only use major version of Piston, minor releases are automatically used.
- Updated README.
- Moved the context origin to 0x0 outside of the draw loop (#67)
- Renamed BaseWidget to CanvasWidget (#27)
- Removed autoclip config, as this will be automatic. (#20)
- Context reset automatically takes place before each draw (#21)