### PR TITLE
0.2.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,7 @@ path = "src/lib.rs"
 
 [dependencies]
 piston_window = "^0.89"
+pistoncore-sdl2_window = "^0.55"
+lazy_static = "^1.3"
 rand = "0.3"
 find_folder = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 
 [dependencies]
 piston_window = "^0.89"
-pistoncore-sdl2_window = "^0.55"
+pistoncore-glfw_window = "^0.49"
 lazy_static = "^1.3"
 rand = "0.3"
 find_folder = "^0.3"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I wanted to keep these specific design ideas in mind:
 
 - Maintainable with little effort
 - Easily extensible
+- Lightweight enough to run on minimalist hardware
 - **Easy to use and understand**
 
 These design ideas are critical.  **Keep it simple.  Keep it stupid simple.**
@@ -30,6 +31,8 @@ Pushrod requires the following minimum versions:
 | Library | Version |
 | ------- | ------- |
 | piston_window | 0.89 |
+| pistoncore-glfw_window | 0.49 |
+| lazy_static | 1.3 |
 | rust | 2018 |
 
 ## Runnable Examples

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 - Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
 - Modifying code so that GlfwWindow is now a requirement, as it has implemented window polling with timeout properly.
 - Lessened load on the draw routines; switched max FPS to 30.
+- Fixed drawing functionality on all platforms; issue with doubling clip, which is no longer necessary.
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Added a third radio button to control speed of progress widget in example.
 - Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
 - Improved toggle button behavior, similar to push button. (#120)
+- Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - Fixed bug with debugging: when selecting checkbox, now toggles hide/show rather than clearing out text. (#116)
 - Added a third radio button to control speed of progress widget in example.
+- Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 0.2.10
 
 - Fixed bug with debugging: when selecting checkbox, now toggles hide/show rather than clearing out text. (#116)
+- Added a third radio button to control speed of progress widget in example.
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Pushrod Releases
 
+## 0.2.10
+
+- Fixed bug with debugging: when selecting checkbox, now toggles hide/show rather than clearing out text. (#116)
+
 ## 0.2.9
 
 - Added radio button images.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 - Improved toggle button behavior, similar to push button. (#120)
 - Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
 - Modifying code so that GlfwWindow is now a requirement, as it has implemented window polling with timeout properly.
+- Lessened load on the draw routines; switched max FPS to 30.
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@
 - Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
 - Improved toggle button behavior, similar to push button. (#120)
 - Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
-- Modifying code so that SDL2Window is now a requirement, as it has implemented window polling with timeout properly.
+- Modifying code so that GlfwWindow is now a requirement, as it has implemented window polling with timeout properly.
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - Fixed bug with debugging: when selecting checkbox, now toggles hide/show rather than clearing out text. (#116)
 - Added a third radio button to control speed of progress widget in example.
 - Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
+- Improved toggle button behavior, similar to push button. (#120)
 
 ## 0.2.9
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
 - Improved toggle button behavior, similar to push button. (#120)
 - Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
+- Modifying code so that SDL2Window is now a requirement, as it has implemented window polling with timeout properly.
 
 ## 0.2.9
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,10 +14,13 @@
 // limitations under the License.
 
 extern crate pushrod;
+extern crate sdl2_window;
 
 use std::cell::RefCell;
 
 use piston_window::*;
+use sdl2_window::Sdl2Window;
+
 use pushrod::core::callbacks::*;
 use pushrod::core::main::*;
 use pushrod::core::widget_store::*;
@@ -814,7 +817,7 @@ impl SimpleWindow {
 }
 
 fn main() {
-    let window: PistonWindow = WindowSettings::new("Pushrod Window", [800, 600])
+    let window: PistonWindow<Sdl2Window> = WindowSettings::new("Pushrod Window", [800, 600])
         .opengl(OpenGL::V3_2)
         .resizable(true)
         .build()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -40,62 +40,49 @@ pub struct SimpleWindow {
 pub struct SimpleWindowEventHandler {
     animated: bool,
     progress: u16,
-    debugging: bool,
 }
 
 impl PushrodCallbackEvents for SimpleWindowEventHandler {
     fn handle_event(&mut self, event: CallbackEvent, widget_store: &mut WidgetStore) {
         match event {
             CallbackEvent::MouseEntered { widget_id } => {
-                if self.debugging {
-                    // When a mouse enters a widget, the ID will get modified; modify the debug widget
-                    // with the ID that was specified.
-                    let widget_name = String::from(widget_store.get_name_for_widget_id(widget_id));
-                    let widget_point = widget_store
-                        .get_widget_for_id(widget_id)
-                        .borrow_mut()
-                        .config()
-                        .get_point(CONFIG_ORIGIN);
-                    let widget_size = widget_store
-                        .get_widget_for_id(widget_id)
-                        .borrow_mut()
-                        .config()
-                        .get_size(CONFIG_BODY_SIZE);
+                // When a mouse enters a widget, the ID will get modified; modify the debug widget
+                // with the ID that was specified.
+                let widget_name = String::from(widget_store.get_name_for_widget_id(widget_id));
+                let widget_point = widget_store
+                    .get_widget_for_id(widget_id)
+                    .borrow_mut()
+                    .config()
+                    .get_point(CONFIG_ORIGIN);
+                let widget_size = widget_store
+                    .get_widget_for_id(widget_id)
+                    .borrow_mut()
+                    .config()
+                    .get_size(CONFIG_BODY_SIZE);
 
-                    widget_store
-                        .get_widget_for_name("DebugText1")
-                        .borrow_mut()
-                        .set_config(
-                            CONFIG_DISPLAY_TEXT,
-                            Config::Text(format!(
-                                "Current Widget: {} ({})",
-                                widget_id, widget_name
-                            ))
-                            .clone(),
-                        );
+                widget_store
+                    .get_widget_for_name("DebugText1")
+                    .borrow_mut()
+                    .set_config(
+                        CONFIG_DISPLAY_TEXT,
+                        Config::Text(format!(
+                            "Current Widget: {} ({})",
+                            widget_id, widget_name
+                        ))
+                        .clone(),
+                    );
 
-                    widget_store
-                        .get_widget_for_name("DebugText2")
-                        .borrow_mut()
-                        .set_config(
-                            CONFIG_DISPLAY_TEXT,
-                            Config::Text(format!(
-                                "Dimensions: x={} y={} w={} h={}",
-                                widget_point.x, widget_point.y, widget_size.w, widget_size.h
-                            ))
-                            .clone(),
-                        );
-                } else {
-                    widget_store
-                        .get_widget_for_name("DebugText1")
-                        .borrow_mut()
-                        .set_config(CONFIG_DISPLAY_TEXT, Config::Text(String::from("")));
-
-                    widget_store
-                        .get_widget_for_name("DebugText2")
-                        .borrow_mut()
-                        .set_config(CONFIG_DISPLAY_TEXT, Config::Text(String::from("")));
-                }
+                widget_store
+                    .get_widget_for_name("DebugText2")
+                    .borrow_mut()
+                    .set_config(
+                        CONFIG_DISPLAY_TEXT,
+                        Config::Text(format!(
+                            "Dimensions: x={} y={} w={} h={}",
+                            widget_point.x, widget_point.y, widget_size.w, widget_size.h
+                        ))
+                        .clone(),
+                    );
             }
 
             CallbackEvent::WidgetClicked { widget_id, button } => {
@@ -302,19 +289,14 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                 }
 
                 "DebugCheck1" => {
-                    self.debugging = selected;
-
-                    if !self.debugging {
-                        widget_store
-                            .get_widget_for_name("DebugText1")
-                            .borrow_mut()
-                            .set_config(CONFIG_DISPLAY_TEXT, Config::Text(String::from("")));
-
-                        widget_store
-                            .get_widget_for_name("DebugText2")
-                            .borrow_mut()
-                            .set_config(CONFIG_DISPLAY_TEXT, Config::Text(String::from("")));
-                    }
+                    widget_store
+                        .get_widget_for_name("DebugText1")
+                        .borrow_mut()
+                        .set_toggle(CONFIG_WIDGET_HIDDEN, !selected);
+                    widget_store
+                        .get_widget_for_name("DebugText2")
+                        .borrow_mut()
+                        .set_toggle(CONFIG_WIDGET_HIDDEN, !selected);
                 }
 
                 "Radio1" => {
@@ -369,7 +351,6 @@ impl SimpleWindowEventHandler {
         SimpleWindowEventHandler {
             animated: false,
             progress: 50,
-            debugging: true,
         }
     }
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -308,7 +308,14 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                 }
 
                 "Radio2" => {
-                    eprintln!("Setting timer 500");
+                    widget_store
+                        .get_widget_for_name("TimerWidget1")
+                        .borrow_mut()
+                        .config()
+                        .set_numeric(CONFIG_TIMER_TIMEOUT, 300);
+                }
+
+                "Radio3" => {
                     widget_store
                         .get_widget_for_name("TimerWidget1")
                         .borrow_mut()
@@ -625,14 +632,14 @@ impl SimpleWindow {
         let mut radio_1 = RadioButtonWidget::new(
             self.pushrod.borrow_mut().get_factory(),
             "OpenSans-Regular.ttf".to_string(),
-            "Fast".to_string(),
+            "1".to_string(),
             20,
             TextJustify::Left,
             true,
         );
 
         radio_1.set_point(CONFIG_ORIGIN, 20, 400);
-        radio_1.set_size(CONFIG_BODY_SIZE, 115, 32);
+        radio_1.set_size(CONFIG_BODY_SIZE, 75, 32);
         radio_1.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
         radio_1.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         radio_1.set_numeric(CONFIG_WIDGET_GROUP_ID, 1);
@@ -643,20 +650,38 @@ impl SimpleWindow {
         let mut radio_2 = RadioButtonWidget::new(
             self.pushrod.borrow_mut().get_factory(),
             "OpenSans-Regular.ttf".to_string(),
-            "Slow".to_string(),
+            "2".to_string(),
             20,
             TextJustify::Left,
             false,
         );
 
-        radio_2.set_point(CONFIG_ORIGIN, 136, 400);
-        radio_2.set_size(CONFIG_BODY_SIZE, 115, 32);
+        radio_2.set_point(CONFIG_ORIGIN, 100, 400);
+        radio_2.set_size(CONFIG_BODY_SIZE, 75, 32);
         radio_2.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
         radio_2.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         radio_2.set_numeric(CONFIG_WIDGET_GROUP_ID, 1);
         self.pushrod
             .borrow_mut()
             .add_widget("Radio2", Box::new(radio_2));
+
+        let mut radio_3 = RadioButtonWidget::new(
+            self.pushrod.borrow_mut().get_factory(),
+            "OpenSans-Regular.ttf".to_string(),
+            "3".to_string(),
+            20,
+            TextJustify::Left,
+            false,
+        );
+
+        radio_3.set_point(CONFIG_ORIGIN, 180, 400);
+        radio_3.set_size(CONFIG_BODY_SIZE, 75, 32);
+        radio_3.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
+        radio_3.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
+        radio_3.set_numeric(CONFIG_WIDGET_GROUP_ID, 1);
+        self.pushrod
+            .borrow_mut()
+            .add_widget("Radio3", Box::new(radio_3));
 
         let mut progress_text = TextWidget::new(
             self.pushrod.borrow_mut().get_factory(),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,12 +14,12 @@
 // limitations under the License.
 
 extern crate pushrod;
-extern crate sdl2_window;
+extern crate glfw_window;
 
 use std::cell::RefCell;
 
 use piston_window::*;
-use sdl2_window::Sdl2Window;
+use glfw_window::GlfwWindow;
 
 use pushrod::core::callbacks::*;
 use pushrod::core::main::*;
@@ -817,7 +817,7 @@ impl SimpleWindow {
 }
 
 fn main() {
-    let window: PistonWindow<Sdl2Window> = WindowSettings::new("Pushrod Window", [800, 600])
+    let window: PistonWindow<GlfwWindow> = WindowSettings::new("Pushrod Window", [800, 600])
         .opengl(OpenGL::V3_2)
         .resizable(true)
         .build()

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -124,7 +124,7 @@ impl Pushrod {
     ///   - Swap display buffers if required
     ///
     /// This event is handled window-by-window.  Once a window has processed all of its pending
-    /// events, the next window is then processed.  No particular window takes precidence - any
+    /// events, the next window is then processed.  No particular window takes precedence - any
     /// window that has events to process gets handled in order.
     pub fn run(&mut self, event_handler: &mut PushrodCallbackEvents) {
         let mut last_widget_id = -1;
@@ -144,9 +144,9 @@ impl Pushrod {
         eprintln!("Injectable Map: {:?}", injectable_map);
 
         while let ref event = &self.window.wait_event_timeout(Duration::from_millis(50)) {
-//            self.window.draw_2d(&event, |ctx, gl| {
-//                eprintln!("Draw");
-//            });
+            self.window.draw_2d(&event, |ctx, gl| {
+                eprintln!("Draw");
+            });
 
             match event {
                 // Mouse movement

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -100,7 +100,6 @@ impl Pushrod {
 
         match injectable_event {
             Some(new_event) => {
-                eprintln!("Inject event: {:?}", new_event);
                 event_handler.handle_event(new_event.clone(), &mut self.widget_store.borrow_mut())
             }
             None => (),
@@ -192,15 +191,6 @@ impl Pushrod {
                                 },
                             );
                         }
-
-                        eprintln!(
-                            "Widget IDs: current={} parent={} children={:?}",
-                            current_widget_id,
-                            current_parent_for_widget,
-                            self.widget_store
-                                .borrow_mut()
-                                .get_children_of(current_widget_id)
-                        );
                     }
                 }
             });

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -139,6 +139,8 @@ impl Pushrod {
             .collect();
 
         eprintln!("Injectable Map: {:?}", injectable_map);
+        eprintln!("Window Size: {:?}", self.window.size());
+        eprintln!("Draw Size: {:?}", self.window.window.draw_size());
 
         self.window.set_max_fps(30);
 

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -137,6 +137,8 @@ impl Pushrod {
             .map(|x| x.widget_id)
             .collect();
 
+        self.window.set_lazy(true);
+
         eprintln!("Injectable Map: {:?}", injectable_map);
 
         while let Some(ref event) = &self.window.next() {

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -152,10 +152,6 @@ impl Pushrod {
                         .widget_store
                         .borrow_mut()
                         .get_widget_id_for_point(mouse_point.clone());
-                    let current_parent_for_widget = self
-                        .widget_store
-                        .borrow_mut()
-                        .get_parent_of(current_widget_id);
 
                     // Handles the mouse move callback.
                     if current_widget_id != -1 {

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -144,7 +144,12 @@ impl Pushrod {
         eprintln!("Injectable Map: {:?}", injectable_map);
 
         while let ref event = &self.window.wait_event_timeout(Duration::from_millis(50)) {
+//            self.window.draw_2d(&event, |ctx, gl| {
+//                eprintln!("Draw");
+//            });
+
             match event {
+                // Mouse movement
                 Some(Input::Move(Motion::MouseCursor(ref x, ref y))) => {
                     let mouse_point = make_point_f64(*x, *y);
 
@@ -193,6 +198,23 @@ impl Pushrod {
                     }
                 },
 
+                // Mouse scroll wheel
+                Some(Input::Move(Motion::MouseScroll(ref x, ref y))) => {
+                    let mouse_point = make_point_f64(*x, *y);
+
+                    if last_widget_id != -1 {
+                        self.handle_event(
+                            last_widget_id,
+                            event_handler,
+                            CallbackEvent::MouseScrolled {
+                                widget_id: last_widget_id,
+                                point: mouse_point.clone(),
+                            },
+                        );
+                    }
+                },
+
+                // Keyboard input
                 Some(Input::Button(ButtonArgs {
                     state,
                     button: Button::Keyboard(key),
@@ -209,26 +231,35 @@ impl Pushrod {
                     );
                 },
 
+                // Window focus
+                Some(Input::Focus(ref focused)) => {
+                    self.handle_event(
+                        last_widget_id,
+                        event_handler,
+                        CallbackEvent::WindowFocused { flag: *focused },
+                    )
+                },
+
+                // Window resize
+                Some(Input::Resize(ref w, ref h)) => {
+                    event_handler.handle_event(
+                        CallbackEvent::WindowResized {
+                            size: crate::core::point::Size {
+                                w: *w as i32,
+                                h: *h as i32,
+                            },
+                        },
+                        &mut self.widget_store.borrow_mut(),
+                    );
+
+                    self.widget_store.borrow_mut().invalidate_all_widgets();
+                }
+
                 None => eprintln!("None."),
 
-                _ => eprintln!("{:?}", event),
+                _ => eprintln!("Event: {:?}", event),
             }
 
-//            event.mouse_scroll(|x, y| {
-//                let mouse_point = make_point_f64(x, y);
-//
-//                if last_widget_id != -1 {
-//                    self.handle_event(
-//                        last_widget_id,
-//                        event_handler,
-//                        CallbackEvent::MouseScrolled {
-//                            widget_id: last_widget_id,
-//                            point: mouse_point.clone(),
-//                        },
-//                    );
-//                }
-//            });
-//
 //            event.button(|args| match args.state {
 //                ButtonState::Press => {
 //                    button_map
@@ -277,30 +308,6 @@ impl Pushrod {
 //                        }
 //                    }
 //                }
-//            });
-//
-//            event.resize(|w, h| {
-//                event_handler.handle_event(
-//                    CallbackEvent::WindowResized {
-//                        size: crate::core::point::Size {
-//                            w: w as i32,
-//                            h: h as i32,
-//                        },
-//                    },
-//                    &mut self.widget_store.borrow_mut(),
-//                );
-//            });
-//
-//            event.focus(|focused| {
-//                self.handle_event(
-//                    last_widget_id,
-//                    event_handler,
-//                    CallbackEvent::WindowFocused { flag: focused },
-//                );
-//            });
-//
-//            event.resize(|_, _| {
-//                self.widget_store.borrow_mut().invalidate_all_widgets();
 //            });
 //
 //            // FPS loop handling

--- a/src/core/point.rs
+++ b/src/core/point.rs
@@ -14,7 +14,7 @@
 
 /// Structure identifying a point on the screen by X and Y coordinates.  X and Y coordinates
 /// are represented from the upper left-hand corner of the base object.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Point {
     pub x: i32,
     pub y: i32,
@@ -23,7 +23,7 @@ pub struct Point {
 /// Structure identifying a size of an object by W (width) and H (height), respectively.
 /// Other systems may use "width" and "height" as nomenclature, however, we wanted to keep
 /// naming consistent.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Size {
     pub w: i32,
     pub h: i32,

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -264,10 +264,10 @@ impl WidgetStore {
                     };
 
                     let clip: DrawState = c.draw_state.scissor([
-                        origin.x as u32 * 2,
-                        origin.y as u32 * 2,
-                        size.w as u32 * 2,
-                        size.h as u32 * 2,
+                        origin.x as u32,
+                        origin.y as u32,
+                        size.w as u32,
+                        size.h as u32,
                     ]);
 
                     &paint_widget.widget.borrow_mut().draw(new_context, g, &clip);

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -88,13 +88,13 @@ impl Widget for PushButtonWidget {
     fn handle_event(&mut self, injected: bool, event: CallbackEvent) -> Option<CallbackEvent> {
         if !injected {
             match event {
-                CallbackEvent::MouseEntered { widget_id } => {
+                CallbackEvent::MouseEntered { widget_id: _ } => {
                     if self.active {
                         self.draw_hovered();
                     }
                 }
 
-                CallbackEvent::MouseExited { widget_id } => {
+                CallbackEvent::MouseExited { widget_id: _ } => {
                     if self.active {
                         self.draw_unhovered();
                     }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -131,8 +131,8 @@ impl Widget for PushButtonWidget {
                 } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            self.active = false;
                             self.draw_unhovered();
+                            self.active = false;
                         }
                     }
                     _ => (),

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -31,6 +31,7 @@ pub struct PushButtonWidget {
     config: Configurable,
     base_widget: BoxWidget,
     text_widget: TextWidget,
+    active: bool,
 }
 
 /// Implementation of the constructor for the `PushButtonWidget`.
@@ -52,7 +53,20 @@ impl PushButtonWidget {
                 font_size,
                 justify,
             ),
+            active: false,
         }
+    }
+
+    fn draw_hovered(&mut self) {
+        self.base_widget
+            .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
+        self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
+    }
+
+    fn draw_unhovered(&mut self) {
+        self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
+        self.text_widget
+            .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
     }
 }
 
@@ -74,15 +88,26 @@ impl Widget for PushButtonWidget {
     fn handle_event(&mut self, injected: bool, event: CallbackEvent) -> Option<CallbackEvent> {
         if !injected {
             match event {
+                CallbackEvent::MouseEntered { widget_id } => {
+                    if self.active {
+                        self.draw_hovered();
+                    }
+                }
+
+                CallbackEvent::MouseExited { widget_id } => {
+                    if self.active {
+                        self.draw_unhovered();
+                    }
+                }
+
                 CallbackEvent::MouseButtonDown {
                     widget_id: _,
                     button,
                 } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            self.base_widget
-                                .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                            self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
+                            self.draw_hovered();
+                            self.active = true;
                         }
                     }
                     _ => (),
@@ -91,9 +116,8 @@ impl Widget for PushButtonWidget {
                 CallbackEvent::MouseButtonUpInside { widget_id, button } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
-                            self.text_widget
-                                .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
+                            self.draw_unhovered();
+                            self.active = false;
 
                             return Some(WidgetClicked { widget_id, button });
                         }
@@ -107,9 +131,8 @@ impl Widget for PushButtonWidget {
                 } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
-                            self.text_widget
-                                .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
+                            self.active = false;
+                            self.draw_unhovered();
                         }
                     }
                     _ => (),

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -102,13 +102,13 @@ impl Widget for ToggleButtonWidget {
     fn handle_event(&mut self, injected: bool, event: CallbackEvent) -> Option<CallbackEvent> {
         if !injected {
             match event {
-                CallbackEvent::MouseEntered { widget_id } => {
+                CallbackEvent::MouseEntered { widget_id: _ } => {
                     if self.active {
                         self.draw_hovered();
                     }
                 }
 
-                CallbackEvent::MouseExited { widget_id } => {
+                CallbackEvent::MouseExited { widget_id: _ } => {
                     if self.active {
                         self.draw_unhovered();
                     }

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -32,6 +32,7 @@ pub struct ToggleButtonWidget {
     base_widget: BoxWidget,
     text_widget: TextWidget,
     selected: bool,
+    active: bool,
 }
 
 /// Implementation of the constructor for the `ToggleButtonWidget`.
@@ -55,6 +56,31 @@ impl ToggleButtonWidget {
                 justify,
             ),
             selected,
+            active: false,
+        }
+    }
+
+    fn draw_hovered(&mut self) {
+        if !self.selected {
+            self.base_widget
+                .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
+            self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
+        } else {
+            self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
+            self.text_widget
+                .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
+        }
+    }
+
+    fn draw_unhovered(&mut self) {
+        if !self.selected {
+            self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
+            self.text_widget
+                .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
+        } else {
+            self.base_widget
+                .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
+            self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
         }
     }
 }
@@ -76,21 +102,26 @@ impl Widget for ToggleButtonWidget {
     fn handle_event(&mut self, injected: bool, event: CallbackEvent) -> Option<CallbackEvent> {
         if !injected {
             match event {
+                CallbackEvent::MouseEntered { widget_id } => {
+                    if self.active {
+                        self.draw_hovered();
+                    }
+                }
+
+                CallbackEvent::MouseExited { widget_id } => {
+                    if self.active {
+                        self.draw_unhovered();
+                    }
+                }
+
                 CallbackEvent::MouseButtonDown {
                     widget_id: _,
                     button,
                 } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            if !self.selected {
-                                self.base_widget
-                                    .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                                self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
-                            } else {
-                                self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
-                                self.text_widget
-                                    .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                            }
+                            self.draw_hovered();
+                            self.active = true;
                         }
                     }
                     _ => (),
@@ -100,16 +131,8 @@ impl Widget for ToggleButtonWidget {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
                             self.selected = !self.selected;
-
-                            if self.selected {
-                                self.base_widget
-                                    .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                                self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
-                            } else {
-                                self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
-                                self.text_widget
-                                    .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                            }
+                            self.draw_unhovered();
+                            self.active = false;
 
                             return Some(WidgetSelected {
                                 widget_id,
@@ -127,15 +150,8 @@ impl Widget for ToggleButtonWidget {
                 } => match button {
                     Button::Mouse(mouse_button) => {
                         if mouse_button == MouseButton::Left {
-                            if !self.selected {
-                                self.base_widget.set_color(CONFIG_MAIN_COLOR, [1.0; 4]);
-                                self.text_widget
-                                    .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                            } else {
-                                self.base_widget
-                                    .set_color(CONFIG_MAIN_COLOR, [0.0, 0.0, 0.0, 1.0]);
-                                self.text_widget.set_color(CONFIG_TEXT_COLOR, [1.0; 4]);
-                            }
+                            self.draw_unhovered();
+                            self.active = false;
                         }
                     }
                     _ => (),


### PR DESCRIPTION
- Fixed bug with debugging: when selecting checkbox, now toggles hide/show rather than clearing out text. (#116)
- Added a third radio button to control speed of progress widget in example.
- Improved push button sensitivity, highlights when mouse is in bounds, deselects when out. (#119)
- Improved toggle button behavior, similar to push button. (#120)
- Just bought a huge improvement with set_lazy in the window event loop; need to modify timers.
- Modifying code so that GlfwWindow is now a requirement, as it has implemented window polling with timeout properly.
- Lessened load on the draw routines; switched max FPS to 30.
- Fixed drawing functionality on all platforms; issue with doubling clip, which is no longer necessary.
