### PR TITLE
0.4.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## 0.4.5
 
+- Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
+
 ## 0.4.4
 
 - Cleaned up sample code.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## 0.4.5
 
 - Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
+- Fixed all other on_click callbacks so that widgets from widget store are included
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # Pushrod Releases
 
+## 0.4.5
+
 ## 0.4.4
 
 - Cleaned up sample code.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
 - Fixed all other on_click callbacks so that widgets from widget store are included
 - Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
+- Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a sturcture
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
 - Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a sturcture
 - Converted callbacks to use get_callbacks() function for setting callback closures
+- Modified PushButtonWidget to use get_callbacks()
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Fixed all other on_click callbacks so that widgets from widget store are included
 - Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
 - Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a sturcture
+- Converted callbacks to use get_callbacks() function for setting callback closures
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
 - Fixed all other on_click callbacks so that widgets from widget store are included
+- Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,11 +5,12 @@
 - Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
 - Fixed all other on_click callbacks so that widgets from widget store are included
 - Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
-- Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a sturcture
+- Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a structure
 - Converted callbacks to use get_callbacks() function for setting callback closures
 - Modified PushButtonWidget to use get_callbacks()
 - Added on_toggle callback (#190)
 - Added on_mouse_move callback (#183)
+- Optimized callbacks so that they are processed only if populated
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 - Converted callbacks to use get_callbacks() function for setting callback closures
 - Modified PushButtonWidget to use get_callbacks()
 - Added on_toggle callback (#190)
+- Added on_mouse_move callback (#183)
 
 ## 0.4.4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 - Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a sturcture
 - Converted callbacks to use get_callbacks() function for setting callback closures
 - Modified PushButtonWidget to use get_callbacks()
+- Added on_toggle callback (#190)
 
 ## 0.4.4
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -597,7 +597,8 @@ impl SimpleWindow {
         button1.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button1.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button1.on_click(|x, widgets| {
+        button1.get_callbacks()
+            .on_click(|x, widgets| {
             let state = get_widget_by_name(widgets, "BoxInLayoutWidget1".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_HIDDEN);
@@ -633,7 +634,8 @@ impl SimpleWindow {
         button3.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button3.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button3.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button3.on_click(|x, widgets| {
+        button3.get_callbacks()
+            .on_click(|x, widgets| {
             let state = get_widget_by_name(widgets, "BoxInLayoutWidget2".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_DISABLED);
@@ -679,7 +681,8 @@ impl SimpleWindow {
         button5.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button5.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button5.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button5.on_click(|x, widgets| {
+        button5.get_callbacks()
+            .on_click(|x, widgets| {
             get_widget_by_name(widgets, "BoxInLayoutWidget3".to_string()).set_config(
                 CONFIG_MAIN_COLOR,
                 Config::Color([
@@ -790,7 +793,8 @@ impl SimpleWindow {
         button2.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button2.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button2.on_click(|x, widgets| {
+        button2.get_callbacks()
+            .on_click(|x, widgets| {
             get_widget_by_name(widgets, "ProgressWidget".to_string()).set_config(
                 CONFIG_SECONDARY_COLOR,
                 Config::Color([

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -597,8 +597,7 @@ impl SimpleWindow {
         button1.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button1.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button1.get_callbacks()
-            .on_click(|x, widgets| {
+        button1.get_callbacks().on_click(|x, widgets| {
             let state = get_widget_by_name(widgets, "BoxInLayoutWidget1".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_HIDDEN);
@@ -634,8 +633,7 @@ impl SimpleWindow {
         button3.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button3.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button3.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button3.get_callbacks()
-            .on_click(|x, widgets| {
+        button3.get_callbacks().on_click(|x, widgets| {
             let state = get_widget_by_name(widgets, "BoxInLayoutWidget2".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_DISABLED);
@@ -681,8 +679,7 @@ impl SimpleWindow {
         button5.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button5.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button5.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button5.get_callbacks()
-            .on_click(|x, widgets| {
+        button5.get_callbacks().on_click(|x, widgets| {
             get_widget_by_name(widgets, "BoxInLayoutWidget3".to_string()).set_config(
                 CONFIG_MAIN_COLOR,
                 Config::Color([
@@ -793,8 +790,7 @@ impl SimpleWindow {
         button2.set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button2.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
-        button2.get_callbacks()
-            .on_click(|x, widgets| {
+        button2.get_callbacks().on_click(|x, widgets| {
             get_widget_by_name(widgets, "ProgressWidget".to_string()).set_config(
                 CONFIG_SECONDARY_COLOR,
                 Config::Color([

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -598,10 +598,7 @@ impl SimpleWindow {
         button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button1.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button1.on_click(|x, widgets| {
-            let state = widgets
-                [get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            let state = get_widget_by_name(widgets, "BoxInLayoutWidget1".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_HIDDEN);
             let button_text = if state == true {
@@ -612,10 +609,7 @@ impl SimpleWindow {
 
             x.set_config(CONFIG_DISPLAY_TEXT, Config::Text(button_text));
 
-            widgets
-                [get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "BoxInLayoutWidget1".to_string())
                 .set_toggle(CONFIG_WIDGET_HIDDEN, !state);
 
             invalidate_all_widgets_except(widgets, x.get_widget_id());
@@ -640,10 +634,7 @@ impl SimpleWindow {
         button3.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button3.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button3.on_click(|x, widgets| {
-            let state = widgets
-                [get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            let state = get_widget_by_name(widgets, "BoxInLayoutWidget2".to_string())
                 .config()
                 .get_toggle(CONFIG_WIDGET_DISABLED);
             let button_text = if state == true {
@@ -654,30 +645,19 @@ impl SimpleWindow {
 
             x.set_config(CONFIG_DISPLAY_TEXT, Config::Text(button_text));
 
-            widgets
-                [get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "BoxInLayoutWidget2".to_string())
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
 
-            widgets[get_widget_position_by_name(widgets, "MiniBox1".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "MiniBox1".to_string())
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
 
-            widgets[get_widget_position_by_name(widgets, "MiniBox2".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "MiniBox2".to_string())
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
 
-            widgets[get_widget_position_by_name(widgets, "MiniBox3".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "MiniBox3".to_string())
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
 
-            widgets[get_widget_position_by_name(widgets, "MiniBox4".to_string()) as usize]
-                .widget
-                .borrow_mut()
+            get_widget_by_name(widgets, "MiniBox4".to_string())
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
         });
 
@@ -700,9 +680,8 @@ impl SimpleWindow {
         button5.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button5.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button5.on_click(|x, widgets| {
-            let bilw3 = get_widget_position_by_name(widgets, "BoxInLayoutWidget3".to_string());
-
-            widgets[bilw3 as usize].widget.borrow_mut().set_config(
+            get_widget_by_name(widgets, "BoxInLayoutWidget3".to_string())
+                .set_config(
                 CONFIG_MAIN_COLOR,
                 Config::Color([
                     (rand::random::<u8>() as f32 / 255.0),
@@ -813,9 +792,8 @@ impl SimpleWindow {
         button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button2.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button2.on_click(|x, widgets| {
-            let widget_id = get_widget_position_by_name(widgets, "ProgressWidget".to_string());
-
-            widgets[widget_id as usize].widget.borrow_mut().set_config(
+            get_widget_by_name(widgets, "ProgressWidget".to_string())
+                .set_config(
                 CONFIG_SECONDARY_COLOR,
                 Config::Color([
                     (rand::random::<u8>() as f32 / 255.0),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -598,7 +598,8 @@ impl SimpleWindow {
         button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button1.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button1.on_click(|x, widgets| {
-            let state = widgets[get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
+            let state = widgets
+                [get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
                 .widget
                 .borrow_mut()
                 .config()
@@ -611,7 +612,8 @@ impl SimpleWindow {
 
             x.set_config(CONFIG_DISPLAY_TEXT, Config::Text(button_text));
 
-            widgets[get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
+            widgets
+                [get_widget_position_by_name(widgets, "BoxInLayoutWidget1".to_string()) as usize]
                 .widget
                 .borrow_mut()
                 .set_toggle(CONFIG_WIDGET_HIDDEN, !state);
@@ -638,7 +640,8 @@ impl SimpleWindow {
         button3.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button3.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button3.on_click(|x, widgets| {
-            let state = widgets[get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
+            let state = widgets
+                [get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
                 .widget
                 .borrow_mut()
                 .config()
@@ -651,7 +654,8 @@ impl SimpleWindow {
 
             x.set_config(CONFIG_DISPLAY_TEXT, Config::Text(button_text));
 
-            widgets[get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
+            widgets
+                [get_widget_position_by_name(widgets, "BoxInLayoutWidget2".to_string()) as usize]
                 .widget
                 .borrow_mut()
                 .set_toggle(CONFIG_WIDGET_DISABLED, !state);
@@ -698,18 +702,15 @@ impl SimpleWindow {
         button5.on_click(|x, widgets| {
             let bilw3 = get_widget_position_by_name(widgets, "BoxInLayoutWidget3".to_string());
 
-            widgets[bilw3 as usize]
-                .widget
-                .borrow_mut()
-                .set_config(
-                    CONFIG_MAIN_COLOR,
-                    Config::Color([
-                        (rand::random::<u8>() as f32 / 255.0),
-                        (rand::random::<u8>() as f32 / 255.0),
-                        (rand::random::<u8>() as f32 / 255.0),
-                        1.0,
-                    ]),
-                );
+            widgets[bilw3 as usize].widget.borrow_mut().set_config(
+                CONFIG_MAIN_COLOR,
+                Config::Color([
+                    (rand::random::<u8>() as f32 / 255.0),
+                    (rand::random::<u8>() as f32 / 255.0),
+                    (rand::random::<u8>() as f32 / 255.0),
+                    1.0,
+                ]),
+            );
         });
 
         self.pushrod.borrow_mut().add_widget_to_layout_manager(
@@ -814,18 +815,15 @@ impl SimpleWindow {
         button2.on_click(|x, widgets| {
             let widget_id = get_widget_position_by_name(widgets, "ProgressWidget".to_string());
 
-            widgets[widget_id as usize]
-                .widget
-                .borrow_mut()
-                .set_config(
-                    CONFIG_SECONDARY_COLOR,
-                    Config::Color([
-                        (rand::random::<u8>() as f32 / 255.0),
-                        (rand::random::<u8>() as f32 / 255.0),
-                        (rand::random::<u8>() as f32 / 255.0),
-                        1.0,
-                    ]),
-                );
+            widgets[widget_id as usize].widget.borrow_mut().set_config(
+                CONFIG_SECONDARY_COLOR,
+                Config::Color([
+                    (rand::random::<u8>() as f32 / 255.0),
+                    (rand::random::<u8>() as f32 / 255.0),
+                    (rand::random::<u8>() as f32 / 255.0),
+                    1.0,
+                ]),
+            );
         });
 
         self.pushrod.borrow_mut().add_widget_to_layout_manager(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -680,8 +680,7 @@ impl SimpleWindow {
         button5.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button5.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button5.on_click(|x, widgets| {
-            get_widget_by_name(widgets, "BoxInLayoutWidget3".to_string())
-                .set_config(
+            get_widget_by_name(widgets, "BoxInLayoutWidget3".to_string()).set_config(
                 CONFIG_MAIN_COLOR,
                 Config::Color([
                     (rand::random::<u8>() as f32 / 255.0),
@@ -792,8 +791,7 @@ impl SimpleWindow {
         button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
         button2.set_color(CONFIG_BORDER_COLOR, [0.0, 0.0, 0.0, 1.0]);
         button2.on_click(|x, widgets| {
-            get_widget_by_name(widgets, "ProgressWidget".to_string())
-                .set_config(
+            get_widget_by_name(widgets, "ProgressWidget".to_string()).set_config(
                 CONFIG_SECONDARY_COLOR,
                 Config::Color([
                     (rand::random::<u8>() as f32 / 255.0),

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -61,16 +61,12 @@ impl Pushrod {
 
     /// Convenience method that adds a `Widget` to the GUI display stack.
     pub fn add_widget(&mut self, name: &str, widget: Box<dyn Widget>) -> i32 {
-        self.widget_store
-            .borrow_mut()
-            .add_widget(name, widget)
+        self.widget_store.borrow_mut().add_widget(name, widget)
     }
 
     /// Convenience method that adds a `LayoutManager` to the layout management stack.
     pub fn add_layout_manager(&mut self, manager: Box<dyn LayoutManager>) -> i32 {
-        self.widget_store
-            .borrow_mut()
-            .add_layout_manager(manager)
+        self.widget_store.borrow_mut().add_layout_manager(manager)
     }
 
     /// Convenience method that adds a `Widget` to a `LayoutManager` by the manager's ID and
@@ -82,7 +78,8 @@ impl Pushrod {
         manager_id: i32,
         position: Point,
     ) -> i32 {
-        let widget_id = self.widget_store
+        let widget_id = self
+            .widget_store
             .borrow_mut()
             .add_widget_to_layout_manager(name, widget, manager_id, position);
 
@@ -113,7 +110,8 @@ impl Pushrod {
         name: &str,
         widget: Box<dyn Widget>,
     ) -> i32 {
-        let parent_id = self.widget_store
+        let parent_id = self
+            .widget_store
             .borrow_mut()
             .get_widget_id_for_name(parent_name);
 
@@ -123,18 +121,17 @@ impl Pushrod {
     }
 
     fn broadcast_event(&mut self, event: CallbackEvent) {
-        let widget_len = self.widget_store
-            .borrow()
-            .widgets
-            .len();
+        let widget_len = self.widget_store.borrow().widgets.len();
 
         for i in 0..widget_len {
-            self.widget_store
-                .borrow()
-                .widgets[i]
+            self.widget_store.borrow().widgets[i]
                 .widget
                 .borrow_mut()
-                .handle_event(false, event.clone(), Some(&self.widget_store.borrow().widgets));
+                .handle_event(
+                    false,
+                    event.clone(),
+                    Some(&self.widget_store.borrow().widgets),
+                );
         }
     }
 
@@ -149,25 +146,23 @@ impl Pushrod {
             return;
         }
 
-        let handles_events = self.widget_store
-            .borrow()
-            .widgets[widget_id as usize]
+        let handles_events = self.widget_store.borrow().widgets[widget_id as usize]
             .widget
             .borrow_mut()
             .handles_events();
 
         let injectable_event = if handles_events {
-            self.widget_store
-                .borrow()
-                .widgets[widget_id as usize]
+            self.widget_store.borrow().widgets[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .handle_event(false, event.clone(),
-                              Some(&self.widget_store.borrow().widgets))
+                .handle_event(
+                    false,
+                    event.clone(),
+                    Some(&self.widget_store.borrow().widgets),
+                )
         } else {
             None
         };
-
 
         event_handler.handle_event(event.clone(), &mut self.widget_store.borrow_mut());
 
@@ -245,7 +240,9 @@ impl Pushrod {
         eprintln!("Window Size: {:?}", self.window.size());
         eprintln!("Draw Size: {:?}", self.window.draw_size());
 
-        Rc::clone(&self.widget_store).borrow_mut().invalidate_all_widgets();
+        Rc::clone(&self.widget_store)
+            .borrow_mut()
+            .invalidate_all_widgets();
         self.rebuild_gl_buffers();
 
         while let Some(ref event) = self.events.next(&mut self.window) {
@@ -442,23 +439,25 @@ impl Pushrod {
                                 // Injects an event to all widgets, allowing them to exhibit custom event handling behavior if
                                 // required.  This is usually used in cases where special triggering needs to take place, like
                                 // an indication of a timeout or transient error.
-                                let widget_size = Rc::clone(&self.widget_store).borrow_mut().widgets.len();
+                                let widget_size =
+                                    Rc::clone(&self.widget_store).borrow_mut().widgets.len();
 
                                 for i in 0..widget_size {
-                                    let handles_events = Rc::clone(&self.widget_store)
-                                        .borrow()
-                                        .widgets[i]
-                                        .widget
-                                        .borrow_mut().handles_events();
-
-                                    if handles_events {
-                                        Rc::clone(&self.widget_store)
-                                            .borrow()
-                                            .widgets[i]
+                                    let handles_events =
+                                        Rc::clone(&self.widget_store).borrow().widgets[i]
                                             .widget
                                             .borrow_mut()
-                                            .handle_event(true, x.clone(),
-                                            Some(&self.widget_store.borrow().widgets));
+                                            .handles_events();
+
+                                    if handles_events {
+                                        Rc::clone(&self.widget_store).borrow().widgets[i]
+                                            .widget
+                                            .borrow_mut()
+                                            .handle_event(
+                                                true,
+                                                x.clone(),
+                                                Some(&self.widget_store.borrow().widgets),
+                                            );
                                     }
                                 }
                             }

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -127,8 +127,8 @@ impl Widget for BoxWidget {
     fn handle_event(
         &mut self,
         injected: bool,
-        event: CallbackEvent,
-        widget_store: Option<&Vec<WidgetContainer>>,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
         if !injected {
         }

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -18,6 +18,7 @@ use opengl_graphics::GlGraphics;
 
 use crate::core::callbacks::*;
 use crate::core::point::{Point, Size};
+use crate::core::widget_store::WidgetContainer;
 use crate::widget::config::*;
 use crate::widget::widget::*;
 
@@ -121,6 +122,22 @@ impl Widget for BoxWidget {
         }
 
         self.invalidate();
+    }
+
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
+        if !injected {
+        }
+
+        None
+    }
+
+    fn handles_events(&mut self) -> bool {
+        true
     }
 
     fn set_widget_id(&mut self, widget_id: i32) {

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -150,5 +150,4 @@ impl Widget for BoxWidget {
     fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
         &mut self.callbacks
     }
-
 }

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -28,6 +28,7 @@ pub struct BoxWidget {
     config: Configurable,
     event_list: Vec<CallbackEvent>,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
 }
 
 impl BoxWidget {
@@ -37,6 +38,7 @@ impl BoxWidget {
             config: Configurable::new(),
             event_list: vec![],
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
         }
     }
 
@@ -144,4 +146,9 @@ impl Widget for BoxWidget {
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
     }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
+    }
+
 }

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -162,7 +162,8 @@ impl Widget for CheckboxWidget {
                             if self.get_callbacks().has_on_toggle() {
                                 match widget_store {
                                     Some(widgets) => {
-                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
+                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take()
+                                        {
                                             cb(self, selected, widgets);
                                             self.get_callbacks().on_toggle = Some(cb);
                                         }

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -36,6 +36,7 @@ pub struct CheckboxWidget {
     selected_widget: ImageWidget,
     unselected_widget: ImageWidget,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
@@ -68,6 +69,7 @@ impl CheckboxWidget {
             selected_widget,
             unselected_widget,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_click: None,
         }
     }
@@ -226,4 +228,9 @@ impl Widget for CheckboxWidget {
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
     }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
+    }
+
 }

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -164,7 +164,12 @@ impl Widget for CheckboxWidget {
         }
     }
 
-    fn handle_event(&mut self, injected: bool, event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         if !injected {
             match event {
                 CallbackEvent::MouseButtonUpInside { widget_id, button } => match button {

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -232,5 +232,4 @@ impl Widget for CheckboxWidget {
     fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
         &mut self.callbacks
     }
-
 }

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -71,17 +71,6 @@ impl CheckboxWidget {
             callbacks: DefaultWidgetCallbacks::new(),
         }
     }
-
-    /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
-    /// of the current `Widget` object as a parameter, so this object can be modified when
-    /// a click is registered, if necessary.  The checkbox' sselected state is also passed
-    /// into the click callback.
-    pub fn click(&mut self, state: bool, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
-            cb(self, state, widgets);
-            self.get_callbacks().on_toggle = Some(cb);
-        }
-    }
 }
 
 impl Drawable for CheckboxWidget {
@@ -168,10 +157,15 @@ impl Widget for CheckboxWidget {
                         if mouse_button == MouseButton::Left {
                             self.selected = !self.selected;
 
+                            let selected = self.selected;
+
                             if self.get_callbacks().has_on_toggle() {
                                 match widget_store {
                                     Some(widgets) => {
-                                        self.click(self.selected, widgets);
+                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
+                                            cb(self, selected, widgets);
+                                            self.get_callbacks().on_toggle = Some(cb);
+                                        }
                                     }
                                     None => (),
                                 }

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -36,7 +36,7 @@ pub struct CheckboxWidget {
     selected_widget: ImageWidget,
     unselected_widget: ImageWidget,
     widget_id: i32,
-    on_click: Option<Box<dyn FnMut(&mut CheckboxWidget, bool, &Vec<WidgetContainer>)>>,
+    on_click: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
 impl CheckboxWidget {
@@ -76,7 +76,7 @@ impl CheckboxWidget {
     /// `Widget`.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut CheckboxWidget, bool, &Vec<WidgetContainer>) + 'static,
+        F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -182,11 +182,13 @@ impl Widget for ImageButtonWidget {
                             self.draw_unhovered();
                             self.active = false;
 
-                            match widget_store {
-                                Some(widgets) => {
-                                    self.click(widgets);
+                            if self.get_callbacks().has_on_click() {
+                                match widget_store {
+                                    Some(widgets) => {
+                                        self.click(widgets);
+                                    }
+                                    None => (),
                                 }
-                                None => (),
                             }
 
                             return Some(WidgetClicked { widget_id, button });

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -37,7 +37,6 @@ pub struct ImageButtonWidget {
     active: bool,
     widget_id: i32,
     callbacks: DefaultWidgetCallbacks,
-    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl ImageButtonWidget {
@@ -66,7 +65,6 @@ impl ImageButtonWidget {
             active: false,
             widget_id: 0,
             callbacks: DefaultWidgetCallbacks::new(),
-            on_click: None,
         }
     }
 
@@ -84,22 +82,13 @@ impl ImageButtonWidget {
         self.invalidate();
     }
 
-    /// Sets a callback closure that can be called when a click is registered for this
-    /// widget.
-    pub fn on_click<F>(&mut self, callback: F)
-    where
-        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
-    {
-        self.on_click = Some(Box::new(callback));
-    }
-
     /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
     /// of the current `Widget` object as a parameter, so this object can be modified when
     /// a click is registered, if necessary.
     pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.on_click.take() {
+        if let Some(mut cb) = self.get_callbacks().on_click.take() {
             cb(self, widgets);
-            self.on_click = Some(cb);
+            self.get_callbacks().on_click = Some(cb);
         }
     }
 }

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -36,6 +36,7 @@ pub struct ImageButtonWidget {
     image_widget: ImageWidget,
     active: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
@@ -64,6 +65,7 @@ impl ImageButtonWidget {
             image_widget,
             active: false,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_click: None,
         }
     }
@@ -246,5 +248,9 @@ impl Widget for ImageButtonWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -36,7 +36,7 @@ pub struct ImageButtonWidget {
     image_widget: ImageWidget,
     active: bool,
     widget_id: i32,
-    on_click: Option<Box<dyn FnMut(&mut ImageButtonWidget, &Vec<WidgetContainer>)>>,
+    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl ImageButtonWidget {
@@ -86,7 +86,7 @@ impl ImageButtonWidget {
     /// widget.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut ImageButtonWidget, &Vec<WidgetContainer>) + 'static,
+        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -81,16 +81,6 @@ impl ImageButtonWidget {
             .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         self.invalidate();
     }
-
-    /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
-    /// of the current `Widget` object as a parameter, so this object can be modified when
-    /// a click is registered, if necessary.
-    pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_click.take() {
-            cb(self, widgets);
-            self.get_callbacks().on_click = Some(cb);
-        }
-    }
 }
 
 impl Drawable for ImageButtonWidget {
@@ -185,7 +175,10 @@ impl Widget for ImageButtonWidget {
                             if self.get_callbacks().has_on_click() {
                                 match widget_store {
                                     Some(widgets) => {
-                                        self.click(widgets);
+                                        if let Some(mut cb) = self.get_callbacks().on_click.take() {
+                                            cb(self, widgets);
+                                            self.get_callbacks().on_click = Some(cb);
+                                        }
                                     }
                                     None => (),
                                 }

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -152,7 +152,12 @@ impl Widget for ImageButtonWidget {
         self.image_widget.set_config(config, config_value.clone());
     }
 
-    fn handle_event(&mut self, injected: bool, event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         if !injected {
             match event {
                 CallbackEvent::MouseEntered { widget_id: _ } => {

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -90,8 +90,8 @@ impl Widget for ImageWidget {
     fn handle_event(
         &mut self,
         injected: bool,
-        event: CallbackEvent,
-        widget_store: Option<&Vec<WidgetContainer>>,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
         if !injected {
         }

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -18,6 +18,8 @@ use opengl_graphics::{GlGraphics, Texture, TextureSettings};
 
 use crate::widget::config::*;
 use crate::widget::widget::*;
+use crate::core::callbacks::*;
+use crate::core::widget_store::*;
 
 /// Draws an image.
 pub struct ImageWidget {
@@ -83,6 +85,22 @@ impl Widget for ImageWidget {
 
     fn get_widget_id(&mut self) -> i32 {
         self.widget_id
+    }
+
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
+        if !injected {
+        }
+
+        None
+    }
+
+    fn handles_events(&mut self) -> bool {
+        true
     }
 
     fn get_injectable_custom_events(&mut self) -> &mut dyn InjectableCustomEvents {

--- a/src/widget/image_widget.rs
+++ b/src/widget/image_widget.rs
@@ -25,6 +25,7 @@ pub struct ImageWidget {
     image: Texture,
     image_size: crate::core::point::Size,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
 }
 
 impl ImageWidget {
@@ -47,6 +48,7 @@ impl ImageWidget {
                 h: texture_height,
             },
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
         }
     }
 }
@@ -93,5 +95,9 @@ impl Widget for ImageWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/progress_widget.rs
+++ b/src/widget/progress_widget.rs
@@ -19,6 +19,8 @@ use opengl_graphics::GlGraphics;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
 use crate::widget::widget::*;
+use crate::core::callbacks::*;
+use crate::core::widget_store::*;
 
 /// Draws a progress bar, with progress being a value from 0 to 100.  Configurable options
 /// are:
@@ -108,6 +110,22 @@ impl Widget for ProgressWidget {
 
     fn get_widget_id(&mut self) -> i32 {
         self.widget_id
+    }
+
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
+        if !injected {
+        }
+
+        None
+    }
+
+    fn handles_events(&mut self) -> bool {
+        true
     }
 
     fn get_injectable_custom_events(&mut self) -> &mut dyn InjectableCustomEvents {

--- a/src/widget/progress_widget.rs
+++ b/src/widget/progress_widget.rs
@@ -16,11 +16,11 @@
 use graphics::*;
 use opengl_graphics::GlGraphics;
 
+use crate::core::callbacks::*;
+use crate::core::widget_store::*;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
 use crate::widget::widget::*;
-use crate::core::callbacks::*;
-use crate::core::widget_store::*;
 
 /// Draws a progress bar, with progress being a value from 0 to 100.  Configurable options
 /// are:
@@ -115,11 +115,10 @@ impl Widget for ProgressWidget {
     fn handle_event(
         &mut self,
         injected: bool,
-        event: CallbackEvent,
-        widget_store: Option<&Vec<WidgetContainer>>,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
-        if !injected {
-        }
+        if !injected {}
 
         None
     }

--- a/src/widget/progress_widget.rs
+++ b/src/widget/progress_widget.rs
@@ -30,6 +30,7 @@ pub struct ProgressWidget {
     config: Configurable,
     base_widget: BoxWidget,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
 }
 
 impl ProgressWidget {
@@ -46,6 +47,7 @@ impl ProgressWidget {
             config: Configurable::new(),
             base_widget: base,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
         }
     }
 }
@@ -118,5 +120,9 @@ impl Widget for ProgressWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -33,6 +33,7 @@ pub struct PushButtonWidget {
     text_widget: TextWidget,
     active: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
@@ -51,6 +52,7 @@ impl PushButtonWidget {
             text_widget,
             active: false,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_click: None,
         }
     }
@@ -210,5 +212,9 @@ impl Widget for PushButtonWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -69,16 +69,6 @@ impl PushButtonWidget {
             .set_color(CONFIG_TEXT_COLOR, [0.0, 0.0, 0.0, 1.0]);
         self.invalidate();
     }
-
-    /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
-    /// of the current `Widget` object as a parameter, so this object can be modified when
-    /// a click is registered, if necessary.
-    pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_click.take() {
-            cb(self, widgets);
-            self.get_callbacks().on_click = Some(cb);
-        }
-    }
 }
 
 impl Drawable for PushButtonWidget {
@@ -150,7 +140,10 @@ impl Widget for PushButtonWidget {
                             if self.get_callbacks().has_on_click() {
                                 match widget_store {
                                     Some(widgets) => {
-                                        self.click(widgets);
+                                        if let Some(mut cb) = self.get_callbacks().on_click.take() {
+                                            cb(self, widgets);
+                                            self.get_callbacks().on_click = Some(cb);
+                                        }
                                     }
                                     None => (),
                                 }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -33,7 +33,7 @@ pub struct PushButtonWidget {
     text_widget: TextWidget,
     active: bool,
     widget_id: i32,
-    on_click: Option<Box<dyn FnMut(&mut PushButtonWidget, &Vec<WidgetContainer>)>>,
+    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl PushButtonWidget {
@@ -73,9 +73,8 @@ impl PushButtonWidget {
     /// widget.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut PushButtonWidget, &Vec<WidgetContainer>) + 'static,
+        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
     {
-        eprintln!("Setting on click callback.");
         self.on_click = Some(Box::new(callback));
     }
 
@@ -121,7 +120,7 @@ impl Widget for PushButtonWidget {
         &mut self,
         injected: bool,
         event: CallbackEvent,
-        _widget_store: Option<&Vec<WidgetContainer>>,
+        widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
         if !injected {
             match event {
@@ -156,7 +155,7 @@ impl Widget for PushButtonWidget {
                             self.draw_unhovered();
                             self.active = false;
 
-                            match _widget_store {
+                            match widget_store {
                                 Some(widgets) => {
                                     self.click(widgets);
                                 }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -21,7 +21,6 @@ use piston::input::*;
 use crate::core::callbacks::CallbackEvent::WidgetClicked;
 use crate::core::callbacks::*;
 use crate::core::widget_store::*;
-use crate::core::point::Point;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
 use crate::widget::text_widget::*;

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -79,13 +79,6 @@ impl PushButtonWidget {
             self.get_callbacks().on_click = Some(cb);
         }
     }
-
-    pub fn mouse_moved(&mut self, point: Point, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_mouse_move.take() {
-            cb(self, point, widgets);
-            self.get_callbacks().on_mouse_move = Some(cb);
-        }
-    }
 }
 
 impl Drawable for PushButtonWidget {
@@ -135,15 +128,6 @@ impl Widget for PushButtonWidget {
                     }
                 }
 
-                CallbackEvent::MouseMoved { widget_id: _, point } => {
-                    match widget_store {
-                        Some(widgets) => {
-                            self.mouse_moved(point.clone(), widgets);
-                        }
-                        None => (),
-                    }
-                }
-
                 CallbackEvent::MouseButtonDown {
                     widget_id: _,
                     button,
@@ -163,11 +147,13 @@ impl Widget for PushButtonWidget {
                             self.draw_unhovered();
                             self.active = false;
 
-                            match widget_store {
-                                Some(widgets) => {
-                                    self.click(widgets);
+                            if self.get_callbacks().has_on_click() {
+                                match widget_store {
+                                    Some(widgets) => {
+                                        self.click(widgets);
+                                    }
+                                    None => (),
                                 }
-                                None => (),
                             }
 
                             return Some(WidgetClicked { widget_id, button });

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -34,7 +34,6 @@ pub struct PushButtonWidget {
     active: bool,
     widget_id: i32,
     callbacks: DefaultWidgetCallbacks,
-    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl PushButtonWidget {
@@ -53,7 +52,6 @@ impl PushButtonWidget {
             active: false,
             widget_id: 0,
             callbacks: DefaultWidgetCallbacks::new(),
-            on_click: None,
         }
     }
 
@@ -71,22 +69,13 @@ impl PushButtonWidget {
         self.invalidate();
     }
 
-    /// Sets a callback closure that can be called when a click is registered for this
-    /// widget.
-    pub fn on_click<F>(&mut self, callback: F)
-    where
-        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
-    {
-        self.on_click = Some(Box::new(callback));
-    }
-
     /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
     /// of the current `Widget` object as a parameter, so this object can be modified when
     /// a click is registered, if necessary.
     pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.on_click.take() {
+        if let Some(mut cb) = self.get_callbacks().on_click.take() {
             cb(self, widgets);
-            self.on_click = Some(cb);
+            self.get_callbacks().on_click = Some(cb);
         }
     }
 }

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -117,7 +117,12 @@ impl Widget for PushButtonWidget {
         self.text_widget.set_config(config, config_value.clone());
     }
 
-    fn handle_event(&mut self, injected: bool, event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         if !injected {
             match event {
                 CallbackEvent::MouseEntered { widget_id: _ } => {
@@ -154,7 +159,7 @@ impl Widget for PushButtonWidget {
                             match _widget_store {
                                 Some(widgets) => {
                                     self.click(widgets);
-                                },
+                                }
                                 None => (),
                             }
 

--- a/src/widget/push_button_widget.rs
+++ b/src/widget/push_button_widget.rs
@@ -21,6 +21,7 @@ use piston::input::*;
 use crate::core::callbacks::CallbackEvent::WidgetClicked;
 use crate::core::callbacks::*;
 use crate::core::widget_store::*;
+use crate::core::point::Point;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
 use crate::widget::text_widget::*;
@@ -78,6 +79,13 @@ impl PushButtonWidget {
             self.get_callbacks().on_click = Some(cb);
         }
     }
+
+    pub fn mouse_moved(&mut self, point: Point, widgets: &Vec<WidgetContainer>) {
+        if let Some(mut cb) = self.get_callbacks().on_mouse_move.take() {
+            cb(self, point, widgets);
+            self.get_callbacks().on_mouse_move = Some(cb);
+        }
+    }
 }
 
 impl Drawable for PushButtonWidget {
@@ -124,6 +132,15 @@ impl Widget for PushButtonWidget {
                 CallbackEvent::MouseExited { widget_id: _ } => {
                     if self.active {
                         self.draw_unhovered();
+                    }
+                }
+
+                CallbackEvent::MouseMoved { widget_id: _, point } => {
+                    match widget_store {
+                        Some(widgets) => {
+                            self.mouse_moved(point.clone(), widgets);
+                        }
+                        None => (),
                     }
                 }
 

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -177,7 +177,12 @@ impl Widget for RadioButtonWidget {
         }
     }
 
-    fn handle_event(&mut self, injected: bool, event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         if !injected {
             match event {
                 CallbackEvent::MouseButtonUpInside { widget_id, button } => match button {

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -40,7 +40,7 @@ pub struct RadioButtonWidget {
     unselected_widget: ImageWidget,
     inject_event: bool,
     widget_id: i32,
-    on_click: Option<Box<dyn FnMut(&mut RadioButtonWidget, &Vec<WidgetContainer>)>>,
+    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl RadioButtonWidget {
@@ -83,7 +83,7 @@ impl RadioButtonWidget {
     /// widget.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut RadioButtonWidget, &Vec<WidgetContainer>) + 'static,
+        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -40,6 +40,7 @@ pub struct RadioButtonWidget {
     unselected_widget: ImageWidget,
     inject_event: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
@@ -75,6 +76,7 @@ impl RadioButtonWidget {
             unselected_widget,
             inject_event: false,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_click: None,
         }
     }
@@ -261,5 +263,9 @@ impl Widget for RadioButtonWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -41,7 +41,6 @@ pub struct RadioButtonWidget {
     inject_event: bool,
     widget_id: i32,
     callbacks: DefaultWidgetCallbacks,
-    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl RadioButtonWidget {
@@ -77,26 +76,16 @@ impl RadioButtonWidget {
             inject_event: false,
             widget_id: 0,
             callbacks: DefaultWidgetCallbacks::new(),
-            on_click: None,
         }
-    }
-
-    /// Sets a callback closure that can be called when a click is registered for this
-    /// widget.
-    pub fn on_click<F>(&mut self, callback: F)
-    where
-        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
-    {
-        self.on_click = Some(Box::new(callback));
     }
 
     /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
     /// of the current `Widget` object as a parameter, so this object can be modified when
     /// a click is registered, if necessary.
     pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.on_click.take() {
+        if let Some(mut cb) = self.get_callbacks().on_click.take() {
             cb(self, widgets);
-            self.on_click = Some(cb);
+            self.get_callbacks().on_click = Some(cb);
         }
     }
 }

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -78,16 +78,6 @@ impl RadioButtonWidget {
             callbacks: DefaultWidgetCallbacks::new(),
         }
     }
-
-    /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
-    /// of the current `Widget` object as a parameter, so this object can be modified when
-    /// a click is registered, if necessary.
-    pub fn click(&mut self, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_click.take() {
-            cb(self, widgets);
-            self.get_callbacks().on_click = Some(cb);
-        }
-    }
 }
 
 impl Drawable for RadioButtonWidget {
@@ -185,7 +175,10 @@ impl Widget for RadioButtonWidget {
                             if self.get_callbacks().has_on_click() {
                                 match widget_store {
                                     Some(widgets) => {
-                                        self.click(widgets);
+                                        if let Some(mut cb) = self.get_callbacks().on_click.take() {
+                                            cb(self, widgets);
+                                            self.get_callbacks().on_click = Some(cb);
+                                        }
                                     }
                                     None => (),
                                 }

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -182,11 +182,13 @@ impl Widget for RadioButtonWidget {
                             self.selected = true;
                             self.inject_event = true;
 
-                            match widget_store {
-                                Some(widgets) => {
-                                    self.click(widgets);
+                            if self.get_callbacks().has_on_click() {
+                                match widget_store {
+                                    Some(widgets) => {
+                                        self.click(widgets);
+                                    }
+                                    None => (),
                                 }
-                                None => (),
                             }
 
                             self.invalidate();

--- a/src/widget/text_widget.rs
+++ b/src/widget/text_widget.rs
@@ -21,10 +21,10 @@ use graphics::draw_state::DrawState;
 use graphics::*;
 use opengl_graphics::{GlGraphics, GlyphCache, TextureSettings};
 
-use crate::widget::config::*;
-use crate::widget::widget::*;
 use crate::core::callbacks::*;
 use crate::core::widget_store::*;
+use crate::widget::config::*;
+use crate::widget::widget::*;
 
 /// Enumeration identifying the justification of the text to be drawn, as long as the bounds
 /// of the object allow for it.
@@ -173,11 +173,10 @@ impl Widget for TextWidget {
     fn handle_event(
         &mut self,
         injected: bool,
-        event: CallbackEvent,
-        widget_store: Option<&Vec<WidgetContainer>>,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
-        if !injected {
-        }
+        if !injected {}
 
         None
     }

--- a/src/widget/text_widget.rs
+++ b/src/widget/text_widget.rs
@@ -23,6 +23,8 @@ use opengl_graphics::{GlGraphics, GlyphCache, TextureSettings};
 
 use crate::widget::config::*;
 use crate::widget::widget::*;
+use crate::core::callbacks::*;
+use crate::core::widget_store::*;
 
 /// Enumeration identifying the justification of the text to be drawn, as long as the bounds
 /// of the object allow for it.
@@ -166,6 +168,22 @@ impl Widget for TextWidget {
 
     fn get_widget_id(&mut self) -> i32 {
         self.widget_id
+    }
+
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
+        if !injected {
+        }
+
+        None
+    }
+
+    fn handles_events(&mut self) -> bool {
+        true
     }
 
     fn get_injectable_custom_events(&mut self) -> &mut dyn InjectableCustomEvents {

--- a/src/widget/text_widget.rs
+++ b/src/widget/text_widget.rs
@@ -46,6 +46,7 @@ pub struct TextWidget {
     pub desired_width: i32,
     need_text_resize: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
 }
 
 impl TextWidget {
@@ -65,6 +66,7 @@ impl TextWidget {
             desired_width: 0 as i32,
             need_text_resize: true,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
         }
     }
 
@@ -176,5 +178,9 @@ impl Widget for TextWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/timer_widget.rs
+++ b/src/widget/timer_widget.rs
@@ -16,10 +16,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::core::callbacks::CallbackEvent;
+use crate::core::widget_store::*;
 use crate::widget::config::*;
 use crate::widget::widget::*;
-use crate::core::callbacks::*;
-use crate::core::widget_store::*;
 
 /// Creates a timer that can be used to generate callbacks based on a timeout.  When a timeout
 /// has been reached, a `TimerTriggered` event is generated.  Set the timer timeout in
@@ -132,11 +131,10 @@ impl Widget for TimerWidget {
     fn handle_event(
         &mut self,
         injected: bool,
-        event: CallbackEvent,
-        widget_store: Option<&Vec<WidgetContainer>>,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
     ) -> Option<CallbackEvent> {
-        if !injected {
-        }
+        if !injected {}
 
         None
     }

--- a/src/widget/timer_widget.rs
+++ b/src/widget/timer_widget.rs
@@ -32,6 +32,7 @@ pub struct TimerWidget {
     initiated: u64,
     triggered: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_tick: Option<Box<dyn FnMut(&mut TimerWidget)>>,
 }
 
@@ -50,6 +51,7 @@ impl TimerWidget {
             initiated: time_ms(),
             triggered: false,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_tick: None,
         }
     }
@@ -140,5 +142,9 @@ impl Widget for TimerWidget {
     fn is_drawable(&mut self) -> bool {
         self.tick();
         false
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/timer_widget.rs
+++ b/src/widget/timer_widget.rs
@@ -18,6 +18,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::core::callbacks::CallbackEvent;
 use crate::widget::config::*;
 use crate::widget::widget::*;
+use crate::core::callbacks::*;
+use crate::core::widget_store::*;
 
 /// Creates a timer that can be used to generate callbacks based on a timeout.  When a timeout
 /// has been reached, a `TimerTriggered` event is generated.  Set the timer timeout in
@@ -125,6 +127,22 @@ impl Widget for TimerWidget {
 
     fn get_widget_id(&mut self) -> i32 {
         self.widget_id
+    }
+
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
+        if !injected {
+        }
+
+        None
+    }
+
+    fn handles_events(&mut self) -> bool {
+        true
     }
 
     fn get_injectable_custom_events(&mut self) -> &mut dyn InjectableCustomEvents {

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -37,7 +37,7 @@ pub struct ToggleButtonWidget {
     selected: bool,
     active: bool,
     widget_id: i32,
-    on_click: Option<Box<dyn FnMut(&mut ToggleButtonWidget, bool, &Vec<WidgetContainer>)>>,
+    on_click: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
 impl ToggleButtonWidget {
@@ -94,7 +94,7 @@ impl ToggleButtonWidget {
     /// widget.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut ToggleButtonWidget, bool, &Vec<WidgetContainer>) + 'static,
+        F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -170,7 +170,8 @@ impl Widget for ToggleButtonWidget {
 
                                 match widget_store {
                                     Some(widgets) => {
-                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
+                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take()
+                                        {
                                             cb(self, selected, widgets);
                                             self.get_callbacks().on_toggle = Some(cb);
                                         }

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -38,7 +38,6 @@ pub struct ToggleButtonWidget {
     active: bool,
     widget_id: i32,
     callbacks: DefaultWidgetCallbacks,
-    on_click: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
 impl ToggleButtonWidget {
@@ -60,7 +59,6 @@ impl ToggleButtonWidget {
             active: false,
             widget_id: 0,
             callbacks: DefaultWidgetCallbacks::new(),
-            on_click: None,
         }
     }
 
@@ -92,23 +90,14 @@ impl ToggleButtonWidget {
         self.invalidate();
     }
 
-    /// Sets a callback closure that can be called when a click is registered for this
-    /// widget.
-    pub fn on_click<F>(&mut self, callback: F)
-    where
-        F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
-    {
-        self.on_click = Some(Box::new(callback));
-    }
-
     /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
     /// of the current `Widget` object as a parameter, so this object can be modified when
     /// a click is registered, if necessary.  Also indicates the state of the object, whether
     /// or not the object has been toggled.
     pub fn click(&mut self, state: bool, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.on_click.take() {
+        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
             cb(self, state, widgets);
-            self.on_click = Some(cb);
+            self.get_callbacks().on_toggle = Some(cb);
         }
     }
 }

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -145,7 +145,12 @@ impl Widget for ToggleButtonWidget {
         }
     }
 
-    fn handle_event(&mut self, injected: bool, event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        injected: bool,
+        event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         if !injected {
             match event {
                 CallbackEvent::MouseEntered { widget_id: _ } => {

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -176,11 +176,13 @@ impl Widget for ToggleButtonWidget {
                             self.draw_unhovered();
                             self.active = false;
 
-                            match widget_store {
-                                Some(widgets) => {
-                                    self.click(self.selected, widgets);
+                            if self.get_callbacks().has_on_toggle() {
+                                match widget_store {
+                                    Some(widgets) => {
+                                        self.click(self.selected, widgets);
+                                    }
+                                    None => (),
                                 }
-                                None => (),
                             }
 
                             return Some(WidgetSelected {

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -89,17 +89,6 @@ impl ToggleButtonWidget {
 
         self.invalidate();
     }
-
-    /// Calls the click `on_click` callback, if set.  Otherwise, ignored.  Sends a reference
-    /// of the current `Widget` object as a parameter, so this object can be modified when
-    /// a click is registered, if necessary.  Also indicates the state of the object, whether
-    /// or not the object has been toggled.
-    pub fn click(&mut self, state: bool, widgets: &Vec<WidgetContainer>) {
-        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
-            cb(self, state, widgets);
-            self.get_callbacks().on_toggle = Some(cb);
-        }
-    }
 }
 
 impl Drawable for ToggleButtonWidget {
@@ -177,9 +166,14 @@ impl Widget for ToggleButtonWidget {
                             self.active = false;
 
                             if self.get_callbacks().has_on_toggle() {
+                                let selected = self.selected;
+
                                 match widget_store {
                                     Some(widgets) => {
-                                        self.click(self.selected, widgets);
+                                        if let Some(mut cb) = self.get_callbacks().on_toggle.take() {
+                                            cb(self, selected, widgets);
+                                            self.get_callbacks().on_toggle = Some(cb);
+                                        }
                                     }
                                     None => (),
                                 }

--- a/src/widget/toggle_button_widget.rs
+++ b/src/widget/toggle_button_widget.rs
@@ -37,6 +37,7 @@ pub struct ToggleButtonWidget {
     selected: bool,
     active: bool,
     widget_id: i32,
+    callbacks: DefaultWidgetCallbacks,
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
@@ -58,6 +59,7 @@ impl ToggleButtonWidget {
             selected: false,
             active: false,
             widget_id: 0,
+            callbacks: DefaultWidgetCallbacks::new(),
             on_click: None,
         }
     }
@@ -244,5 +246,9 @@ impl Widget for ToggleButtonWidget {
 
     fn get_drawable(&mut self) -> &mut dyn Drawable {
         self
+    }
+
+    fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
+        &mut self.callbacks
     }
 }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -144,7 +144,12 @@ pub trait Widget {
     /// top-level GUI events, such as a mouse entering or exiting the bounds of this `Widget`.
     /// If the `injected` flag is set, it indicates that the event supplied was generate by
     /// a `Widget`, and not by the run loop.
-    fn handle_event(&mut self, _injected: bool, _event: CallbackEvent, _widget_store: Option<&Vec<WidgetContainer>>) -> Option<CallbackEvent> {
+    fn handle_event(
+        &mut self,
+        _injected: bool,
+        _event: CallbackEvent,
+        _widget_store: Option<&Vec<WidgetContainer>>,
+    ) -> Option<CallbackEvent> {
         None
     }
 
@@ -282,14 +287,16 @@ pub fn get_widget_position_by_name(widgets: &Vec<WidgetContainer>, name: String)
     match widgets
         .iter()
         .find(|x| x.widget_name == String::from(name.clone()))
-        {
-            Some(x) => x.widget_id,
-            None => 0,
-        }
+    {
+        Some(x) => x.widget_id,
+        None => 0,
+    }
 }
 
 pub fn invalidate_all_widgets_except(widgets: &Vec<WidgetContainer>, skip_id: i32) {
-    widgets
-        .iter()
-        .for_each(|x| if x.widget_id != skip_id { x.widget.borrow_mut().invalidate() } );
+    widgets.iter().for_each(|x| {
+        if x.widget_id != skip_id {
+            x.widget.borrow_mut().invalidate()
+        }
+    });
 }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -288,10 +288,10 @@ pub fn get_widget_by_name(widgets: &Vec<WidgetContainer>, name: String) -> RefMu
     let pos = match widgets
         .iter()
         .find(|x| x.widget_name == String::from(name.clone()))
-        {
-            Some(x) => x.widget_id as usize,
-            None => 0 as usize,
-        };
+    {
+        Some(x) => x.widget_id as usize,
+        None => 0 as usize,
+    };
 
     widgets[pos].widget.borrow_mut()
 }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -200,11 +200,11 @@ pub trait Widget {
         false
     }
 
+    /// Retrieves the callbacks that are registered for the `Widget`.  These callbacks are used
+    /// when a specific event triggers an action - a click, mouse enter/exit, or movement event,
+    /// for example.  The callbacks stored in the `DefaultWidgetCallbacks` object can be used
+    /// to perform static actions.
     fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks;
-
-    fn has_callbacks(&mut self) -> bool {
-        false
-    }
 }
 
 /// Base `Widget` object.  Displays a blank canvas, with the color set by the `CONFIG_MAIN_COLOR`
@@ -302,7 +302,6 @@ impl Widget for CanvasWidget {
     }
 
 }
-
 
 pub struct DefaultWidgetCallbacks {
     on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -330,8 +330,8 @@ impl DefaultWidgetCallbacks {
     }
 
     pub fn on_toggle<F>(&mut self, callback: F)
-        where
-            F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
+    where
+        F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
     {
         self.on_toggle = Some(Box::new(callback));
         self.on_toggle_populated = true;
@@ -342,8 +342,8 @@ impl DefaultWidgetCallbacks {
     }
 
     pub fn on_mouse_move<F>(&mut self, callback: F)
-        where
-            F: FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>) + 'static,
+    where
+        F: FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>) + 'static,
     {
         self.on_mouse_move = Some(Box::new(callback));
         self.on_mouse_move_populated = true;

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -21,12 +21,6 @@ use crate::core::point::{Point, Size};
 use crate::core::widget_store::*;
 use crate::widget::config::*;
 
-pub trait WidgetCallbacks {
-    fn on_click<F>(&mut self, callback: F)
-    where
-        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static;
-}
-
 pub trait Drawable {
     /// Draws the `Widget`'s contents.  Only gets called if the `Widget` is in invalidated
     /// state.  Provides a modified `Context` object that has an origin of `0x0` in drawing
@@ -304,20 +298,29 @@ impl Widget for CanvasWidget {
 
 pub struct DefaultWidgetCallbacks {
     pub on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
+    pub on_toggle: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
 }
 
-impl WidgetCallbacks for DefaultWidgetCallbacks {
-    fn on_click<F>(&mut self, callback: F)
+impl DefaultWidgetCallbacks {
+    pub fn new() -> Self {
+        Self {
+            on_click: None,
+            on_toggle: None,
+        }
+    }
+
+    pub fn on_click<F>(&mut self, callback: F)
     where
         F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
     {
         self.on_click = Some(Box::new(callback));;
     }
-}
 
-impl DefaultWidgetCallbacks {
-    pub fn new() -> Self {
-        Self { on_click: None }
+    pub fn on_toggle<F>(&mut self, callback: F)
+        where
+            F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
+    {
+        self.on_toggle = Some(Box::new(callback));;
     }
 }
 

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -23,8 +23,8 @@ use crate::widget::config::*;
 
 pub trait WidgetCallbacks {
     fn on_click<F>(&mut self, callback: F)
-        where
-            F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static;
+    where
+        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static;
 }
 
 pub trait Drawable {
@@ -300,26 +300,24 @@ impl Widget for CanvasWidget {
     fn get_callbacks(&mut self) -> &mut DefaultWidgetCallbacks {
         &mut self.callbacks
     }
-
 }
 
 pub struct DefaultWidgetCallbacks {
-    on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
+    pub on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
 }
 
 impl WidgetCallbacks for DefaultWidgetCallbacks {
     fn on_click<F>(&mut self, callback: F)
-        where
-            F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static {
+    where
+        F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
+    {
         self.on_click = Some(Box::new(callback));;
     }
 }
 
 impl DefaultWidgetCallbacks {
     pub fn new() -> Self {
-        Self {
-            on_click: None,
-        }
+        Self { on_click: None }
     }
 }
 

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -299,6 +299,7 @@ impl Widget for CanvasWidget {
 pub struct DefaultWidgetCallbacks {
     pub on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
     pub on_toggle: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
+    pub on_mouse_move: Option<Box<dyn FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>)>>,
 }
 
 impl DefaultWidgetCallbacks {
@@ -306,6 +307,7 @@ impl DefaultWidgetCallbacks {
         Self {
             on_click: None,
             on_toggle: None,
+            on_mouse_move: None,
         }
     }
 
@@ -321,6 +323,13 @@ impl DefaultWidgetCallbacks {
             F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
     {
         self.on_toggle = Some(Box::new(callback));;
+    }
+
+    pub fn on_mouse_move<F>(&mut self, callback: F)
+        where
+            F: FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>) + 'static,
+    {
+        self.on_mouse_move = Some(Box::new(callback));;
     }
 }
 

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -14,6 +14,7 @@
 
 use graphics::*;
 use opengl_graphics::GlGraphics;
+use std::cell::RefMut;
 
 use crate::core::callbacks::*;
 use crate::core::point::{Point, Size};
@@ -283,14 +284,16 @@ impl Widget for CanvasWidget {
     }
 }
 
-pub fn get_widget_position_by_name(widgets: &Vec<WidgetContainer>, name: String) -> i32 {
-    match widgets
+pub fn get_widget_by_name(widgets: &Vec<WidgetContainer>, name: String) -> RefMut<Box<dyn Widget>> {
+    let pos = match widgets
         .iter()
         .find(|x| x.widget_name == String::from(name.clone()))
-    {
-        Some(x) => x.widget_id,
-        None => 0,
-    }
+        {
+            Some(x) => x.widget_id as usize,
+            None => 0 as usize,
+        };
+
+    widgets[pos].widget.borrow_mut()
 }
 
 pub fn invalidate_all_widgets_except(widgets: &Vec<WidgetContainer>, skip_id: i32) {

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -300,6 +300,9 @@ pub struct DefaultWidgetCallbacks {
     pub on_click: Option<Box<dyn FnMut(&mut dyn Widget, &Vec<WidgetContainer>)>>,
     pub on_toggle: Option<Box<dyn FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>)>>,
     pub on_mouse_move: Option<Box<dyn FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>)>>,
+    on_click_populated: bool,
+    on_toggle_populated: bool,
+    on_mouse_move_populated: bool,
 }
 
 impl DefaultWidgetCallbacks {
@@ -308,6 +311,9 @@ impl DefaultWidgetCallbacks {
             on_click: None,
             on_toggle: None,
             on_mouse_move: None,
+            on_click_populated: false,
+            on_toggle_populated: false,
+            on_mouse_move_populated: false,
         }
     }
 
@@ -315,21 +321,36 @@ impl DefaultWidgetCallbacks {
     where
         F: FnMut(&mut dyn Widget, &Vec<WidgetContainer>) + 'static,
     {
-        self.on_click = Some(Box::new(callback));;
+        self.on_click = Some(Box::new(callback));
+        self.on_click_populated = true;
+    }
+
+    pub fn has_on_click(&mut self) -> bool {
+        self.on_click_populated
     }
 
     pub fn on_toggle<F>(&mut self, callback: F)
         where
             F: FnMut(&mut dyn Widget, bool, &Vec<WidgetContainer>) + 'static,
     {
-        self.on_toggle = Some(Box::new(callback));;
+        self.on_toggle = Some(Box::new(callback));
+        self.on_toggle_populated = true;
+    }
+
+    pub fn has_on_toggle(&mut self) -> bool {
+        self.on_toggle_populated
     }
 
     pub fn on_mouse_move<F>(&mut self, callback: F)
         where
             F: FnMut(&mut dyn Widget, Point, &Vec<WidgetContainer>) + 'static,
     {
-        self.on_mouse_move = Some(Box::new(callback));;
+        self.on_mouse_move = Some(Box::new(callback));
+        self.on_mouse_move_populated = true;
+    }
+
+    pub fn has_on_mouse_move(&mut self) -> bool {
+        self.on_mouse_move_populated
     }
 }
 


### PR DESCRIPTION
- Changed get_widget_position_by_name to get_widget_by_name (far easier to use)
- Fixed all other on_click callbacks so that widgets from widget store are included
- Genericized on_click to use `dyn Widget` instead of customized `Widget` definition
- Moved callbacks to `DefaultWidgetCallbacks` object so that callbacks are stored in a structure
- Converted callbacks to use get_callbacks() function for setting callback closures
- Modified PushButtonWidget to use get_callbacks()
- Added on_toggle callback (#190)
- Added on_mouse_move callback (#183)
- Optimized callbacks so that they are processed only if populated