### PR TITLE
Replace `Point` struct with `[i32; 2]`

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -167,7 +167,7 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                 CONFIG_DISPLAY_TEXT,
                 Config::Text(format!(
                     "Dimensions: x={} y={} w={} h={}",
-                    widget_point.x, widget_point.y, widget_size.w, widget_size.h
+                    widget_point[0], widget_point[1], widget_size.w, widget_size.h
                 ))
                 .clone(),
             );
@@ -207,17 +207,17 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                 widget_store
                     .get_widget_for_name("LeftJustifiedText")
                     .borrow_mut()
-                    .set_point(CONFIG_ORIGIN, point.x + 16, point.y + 10);
+                    .set_point(CONFIG_ORIGIN, point[0] + 16, point[1] + 10);
 
                 widget_store
                     .get_widget_for_name("CenterJustifiedText")
                     .borrow_mut()
-                    .set_point(CONFIG_ORIGIN, point.x + 16, point.y + 100 - 24);
+                    .set_point(CONFIG_ORIGIN, point[0] + 16, point[1] + 100 - 24);
 
                 widget_store
                     .get_widget_for_name("RightJustifiedText")
                     .borrow_mut()
-                    .set_point(CONFIG_ORIGIN, point.x + 16, point.y + 200 - 54);
+                    .set_point(CONFIG_ORIGIN, point[0] + 16, point[1] + 200 - 54);
 
                 let layout_size2 = widget_store
                     .get_widget_for_name("BoxInLayoutWidget2")
@@ -236,15 +236,15 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                 widget_store
                     .get_widget_for_name("MiniBox1")
                     .borrow_mut()
-                    .set_point(CONFIG_ORIGIN, box2_point.x + 10, box2_point.y + 10);
+                    .set_point(CONFIG_ORIGIN, box2_point[0] + 10, box2_point[1] + 10);
 
                 widget_store
                     .get_widget_for_name("MiniBox2")
                     .borrow_mut()
                     .set_point(
                         CONFIG_ORIGIN,
-                        box2_point.x + (layout_size2.w / 2) + 4,
-                        box2_point.y + 10,
+                        box2_point[0] + (layout_size2.w / 2) + 4,
+                        box2_point[1] + 10,
                     );
 
                 widget_store
@@ -252,8 +252,8 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                     .borrow_mut()
                     .set_point(
                         CONFIG_ORIGIN,
-                        box2_point.x + 10,
-                        box2_point.y + (layout_size2.h / 2) + 4,
+                        box2_point[0] + 10,
+                        box2_point[1] + (layout_size2.h / 2) + 4,
                     );
 
                 widget_store
@@ -261,8 +261,8 @@ impl PushrodCallbackEvents for SimpleWindowEventHandler {
                     .borrow_mut()
                     .set_point(
                         CONFIG_ORIGIN,
-                        box2_point.x + (layout_size2.w / 2) + 4,
-                        box2_point.y + (layout_size2.h / 2) + 4,
+                        box2_point[0] + (layout_size2.w / 2) + 4,
+                        box2_point[1] + (layout_size2.h / 2) + 4,
                     );
             }
             _ => (),

--- a/src/core/horizontal_layout_manager.rs
+++ b/src/core/horizontal_layout_manager.rs
@@ -41,20 +41,20 @@ impl LayoutManager for HorizontalLayoutManager {
         let width_per_widget = size.w / num_widgets;
         let mut widget_origins: Vec<Point> = vec![];
         let mut widget_sizes: Vec<Size> = vec![];
-        let mut current_x: i32 = origin.x;
-        let current_y: i32 = origin.y;
+        let mut current_x: i32 = origin[0];
+        let current_y: i32 = origin[1];
 
         for x in 0..num_widgets {
             if x == 0 {
-                current_x = self.padding.left + origin.x;
+                current_x = self.padding.left + origin[0];
             } else {
                 current_x += width_per_widget + (self.padding.spacing / 2);
             }
 
-            widget_origins.push(Point {
-                x: current_x,
-                y: current_y + self.padding.top,
-            });
+            widget_origins.push([
+                current_x,
+                current_y + self.padding.top,
+            ]);
 
             if x == num_widgets - 1 {
                 widget_sizes.push(Size {

--- a/src/core/main.rs
+++ b/src/core/main.rs
@@ -255,8 +255,8 @@ impl Pushrod {
             event.mouse_cursor(|pos| {
                 let mouse_point = make_point_f64(pos[0], pos[1]);
 
-                if mouse_point.x != previous_mouse_position.x
-                    || mouse_point.y != previous_mouse_position.y
+                if mouse_point[0] != previous_mouse_position[0]
+                    || mouse_point[1] != previous_mouse_position[1]
                 {
                     previous_mouse_position = mouse_point.clone();
 

--- a/src/core/point.rs
+++ b/src/core/point.rs
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Structure identifying a point on the screen by X and Y coordinates.  X and Y coordinates
-/// are represented from the upper left-hand corner of the base object.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct Point {
-    pub x: i32,
-    pub y: i32,
-}
+/// Type identifying a point on the screen by X and Y coordinates.  X and Y coordinates
+/// are represented from the upper left-hand corner of the base object and are at indices 0 and 1,
+/// respectively.
+pub type Point = [i32; 2];
 
 /// Structure identifying a size of an object by W (width) and H (height), respectively.
 /// Other systems may use "width" and "height" as nomenclature, however, we wanted to keep
@@ -31,7 +28,7 @@ pub struct Size {
 
 /// Convenience method to create a new `Point`.
 pub fn make_point_i32(x: i32, y: i32) -> Point {
-    Point { x, y }
+    [x, y]
 }
 
 /// Convenience method to create a `Point` of origin, defined as an X and Y coordinate of 0.
@@ -45,15 +42,15 @@ pub fn make_point_i32(x: i32, y: i32) -> Point {
 /// # }
 /// ```
 pub fn make_origin_point() -> Point {
-    Point { x: 0, y: 0 }
+    [0; 2]
 }
 
 /// Convenience method to convert floating point X and Y positions to a graphical `Point`.
 pub fn make_point_f64(x: f64, y: f64) -> Point {
-    Point {
-        x: x as i32,
-        y: y as i32,
-    }
+    [
+        x as i32,
+        y as i32,
+    ]
 }
 
 /// Convenience method to create a non-existent size, defined as a width and height of 0.

--- a/src/core/vertical_layout_manager.rs
+++ b/src/core/vertical_layout_manager.rs
@@ -41,20 +41,20 @@ impl LayoutManager for VerticalLayoutManager {
         let height_per_widget = (size.h / num_widgets) - (self.padding.spacing / 2);
         let mut widget_origins: Vec<Point> = vec![];
         let mut widget_sizes: Vec<Size> = vec![];
-        let current_x: i32 = origin.x;
-        let mut current_y: i32 = origin.y;
+        let current_x: i32 = origin[0];
+        let mut current_y: i32 = origin[1];
 
         for x in 0..num_widgets {
             if x == 0 {
-                current_y = self.padding.top + origin.y;
+                current_y = self.padding.top + origin[1];
             } else {
                 current_y += height_per_widget + (self.padding.spacing / 2);
             }
 
-            widget_origins.push(Point {
-                x: current_x + self.padding.left,
-                y: current_y,
-            });
+            widget_origins.push([
+                current_x + self.padding.left,
+                current_y,
+            ]);
 
             if x == num_widgets - 1 {
                 widget_sizes.push(Size {

--- a/src/core/widget_store.rs
+++ b/src/core/widget_store.rs
@@ -215,10 +215,10 @@ impl WidgetStore {
 
                 // Skip over item widgets that have a width and height of 0.
                 if widget_size.w > 0 && widget_size.h > 0 {
-                    if point.x >= widget_point.x
-                        && point.x <= widget_point.x + widget_size.w
-                        && point.y >= widget_point.y
-                        && point.y <= widget_point.y + widget_size.h
+                    if point[0] >= widget_point[0]
+                        && point[0] <= widget_point[0] + widget_size.w
+                        && point[1] >= widget_point[1]
+                        && point[1] <= widget_point[1] + widget_size.h
                     {
                         found_id = pos as i32;
                     }
@@ -365,7 +365,7 @@ impl WidgetStore {
 
             eprintln!("Resizing widget: id={}", widget.get_widget_id());
 
-            widget.set_point(CONFIG_ORIGIN, point.x, point.y);
+            widget.set_point(CONFIG_ORIGIN, point[0], point[1]);
             widget.set_size(CONFIG_BODY_SIZE, size.w, size.h);
         }
 
@@ -466,7 +466,7 @@ impl WidgetStore {
                         let new_context: Context = Context {
                             viewport: c.viewport,
                             view: c.view,
-                            transform: c.transform.trans(origin.x as f64, origin.y as f64),
+                            transform: c.transform.trans(origin[0] as f64, origin[1] as f64),
                             draw_state: c.draw_state,
                         };
 
@@ -491,8 +491,8 @@ impl WidgetStore {
                             g.rectangle(
                                 &Rectangle::new([0.0, 0.0, 0.0, 0.8]),
                                 [
-                                    origin.x as f64,
-                                    origin.y as f64,
+                                    origin[0] as f64,
+                                    origin[1] as f64,
                                     size.w as f64,
                                     size.h as f64,
                                 ],

--- a/src/widget/box_widget.rs
+++ b/src/widget/box_widget.rs
@@ -18,7 +18,7 @@ use opengl_graphics::GlGraphics;
 use piston::input::*;
 
 use crate::core::callbacks::*;
-use crate::core::point::{Point, Size};
+use crate::core::point::Size;
 use crate::core::widget_store::WidgetContainer;
 use crate::widget::config::*;
 use crate::widget::widget::*;
@@ -115,12 +115,12 @@ impl Widget for BoxWidget {
     }
 
     fn set_point(&mut self, config: u8, x: i32, y: i32) {
-        self.set_config(config, Config::Point(Point { x, y }));
+        self.set_config(config, Config::Point([x, y]));
 
         if self.widget_id != 0 {
             self.event_list.push(CallbackEvent::WidgetMoved {
                 widget_id: self.widget_id,
-                point: Point { x, y },
+                point: [x, y],
             });
         }
 

--- a/src/widget/checkbox_widget.rs
+++ b/src/widget/checkbox_widget.rs
@@ -19,7 +19,6 @@ use opengl_graphics::GlGraphics;
 use piston::input::*;
 
 use crate::core::callbacks::*;
-use crate::core::point::Point;
 use crate::core::widget_store::*;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
@@ -94,19 +93,19 @@ impl Drawable for CheckboxWidget {
         if self.selected {
             self.selected_widget
                 .get_drawable()
-                .draw_with_offset(c, g, &clip, Point { x: 0, y: 0 });
+                .draw_with_offset(c, g, &clip, [0; 2]);
         } else {
             self.unselected_widget.get_drawable().draw_with_offset(
                 c,
                 g,
                 &clip,
-                Point { x: 0, y: 0 },
+                [0; 2],
             );
         }
 
         self.text_widget
             .get_drawable()
-            .draw_with_offset(c, g, &clip, Point { x: 38, y: 0 });
+            .draw_with_offset(c, g, &clip, [38, 0]);
 
         // Then clear invalidation.
         self.clear_invalidate();

--- a/src/widget/config.rs
+++ b/src/widget/config.rs
@@ -120,7 +120,7 @@ impl Configurable {
 
     /// Sets a point for a configuration key.
     pub fn set_point(&mut self, config: u8, x: i32, y: i32) {
-        self.set(config, Config::Point(Point { x, y }));
+        self.set(config, Config::Point([x, y]));
     }
 
     /// Sets a size for a configuration key.

--- a/src/widget/image_button_widget.rs
+++ b/src/widget/image_button_widget.rs
@@ -20,7 +20,6 @@ use piston::input::*;
 
 use crate::core::callbacks::CallbackEvent::WidgetClicked;
 use crate::core::callbacks::*;
-use crate::core::point::Point;
 use crate::core::widget_store::*;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
@@ -102,15 +101,15 @@ impl Drawable for ImageButtonWidget {
 
         self.image_widget
             .get_drawable()
-            .draw_with_offset(c, g, &clip, Point { x: 2, y: 2 });
+            .draw_with_offset(c, g, &clip, [2, 2]);
         self.text_widget.get_drawable().draw_with_offset(
             c,
             g,
             &clip,
-            Point {
-                x: size.h + border + 4,
-                y: 0,
-            },
+            [
+                size.h + border + 4,
+                0,
+            ],
         );
 
         // Then clear invalidation.

--- a/src/widget/radio_button_widget.rs
+++ b/src/widget/radio_button_widget.rs
@@ -19,7 +19,6 @@ use opengl_graphics::GlGraphics;
 use piston::input::*;
 
 use crate::core::callbacks::*;
-use crate::core::point::Point;
 use crate::core::widget_store::*;
 use crate::widget::box_widget::*;
 use crate::widget::config::*;
@@ -100,14 +99,14 @@ impl Drawable for RadioButtonWidget {
 
         if self.selected {
             self.selected_widget
-                .draw_with_offset(c, g, &clip, Point { x: 0, y: 0 });
+                .draw_with_offset(c, g, &clip, [0; 2]);
         } else {
             self.unselected_widget
-                .draw_with_offset(c, g, &clip, Point { x: 0, y: 0 });
+                .draw_with_offset(c, g, &clip, [0; 2]);
         }
 
         self.text_widget
-            .draw_with_offset(c, g, &clip, Point { x: 38, y: 0 });
+            .draw_with_offset(c, g, &clip, [38, 0]);
 
         // Then clear invalidation.
         self.clear_invalidate();

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -45,7 +45,7 @@ pub trait Drawable {
         point_offset: Point,
     ) {
         self.draw(
-            c.trans(point_offset.x as f64, point_offset.y as f64),
+            c.trans(point_offset[0] as f64, point_offset[1] as f64),
             g,
             clip,
         );
@@ -110,7 +110,7 @@ pub trait Widget {
 
     /// Sets a point value for a configuration key.
     fn set_point(&mut self, config: u8, x: i32, y: i32) {
-        self.set_config(config, Config::Point(Point { x, y }));
+        self.set_config(config, Config::Point([x, y]));
     }
 
     /// Sets a size value for a configuration key.
@@ -262,12 +262,12 @@ impl Widget for CanvasWidget {
     }
 
     fn set_point(&mut self, config: u8, x: i32, y: i32) {
-        self.set_config(config, Config::Point(Point { x, y }));
+        self.set_config(config, Config::Point([x, y]));
 
         if self.widget_id != 0 {
             self.event_list.push(CallbackEvent::WidgetMoved {
                 widget_id: self.widget_id,
-                point: Point { x, y },
+                point: [x, y],
             });
         }
     }


### PR DESCRIPTION
Fixes #174.

I feel like this makes the code creating `Point`s a little unclear. I could change it to a tuple struct containing the array instead, but I can't say how that would affect performance without benchmarks.