### PR TITLE
0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed build process to load in Ubuntu libraries for SDL2 build
 - Updated Ubuntu documentation thanks to @alexislozano
 - Added handler for all other events in a catch-all function for `Widget`s (#227)
+- Fixed travis-ci build for OS X builds
 
 ## 0.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pushrod Change Log
 
+## 0.4.13
+
+- Documentation improvements
+
 ## 0.4.12
 
 - Removed ImagePosition from `ImageWidget`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Documentation improvements
 - Clippy code improvements
+- Changed build process to load in Ubuntu libraries for SDL2 build
+- Updated Ubuntu documentation thanks to @alexislozano
 
 ## 0.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added handler for all other events in a catch-all function for `Widget`s (#227)
 - Fixed travis-ci build for OS X builds
 - Modified `Widget`s so that they display the events sent to them that are unhandled.
+- Added `Layout` class, back ported from the original class, greatly simplified. (#230)
 
 ## 0.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated Ubuntu documentation thanks to @alexislozano
 - Added handler for all other events in a catch-all function for `Widget`s (#227)
 - Fixed travis-ci build for OS X builds
+- Modified `Widget`s so that they display the events sent to them that are unhandled.
 
 ## 0.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Clippy code improvements
 - Changed build process to load in Ubuntu libraries for SDL2 build
 - Updated Ubuntu documentation thanks to @alexislozano
+- Added handler for all other events in a catch-all function for `Widget`s (#227)
 
 ## 0.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.13
 
 - Documentation improvements
+- Clippy code improvements
 
 ## 0.4.12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://www.github.com/KenSuenobu/rust-pushrod/"
 documentation = "http://docs.rs/crate/rust-pushrod/"
-keywords = ["piston", "opengl", "ui", "gui", "conrod"]
+keywords = ["sdl", "sdl2", "opengl", "ui", "gui"]
 categories = ["gui", "graphics", "visualization"]
 include = [
     "**/*.rs",

--- a/README.md
+++ b/README.md
@@ -30,19 +30,6 @@ These design ideas are critical.  **Keep it simple.  Keep it stupid simple.**
 
 ## 0.4.x Status
 
-Widgets - Porting from original Pushrod:
-
-- [x] Text Widget
-  - [x] OpenSans Font Included
-- [x] Image Widget
-- [x] Progress Bar Widget
-- [x] Timer Widget
-- [x] Push Button Widget
-- [x] Image Button Widget
-- [x] Toggle Button Widget
-- [ ] Checkbox Widget
-- [ ] Radio Button Widget (or Group Button Widget)
-
 Soon to follow will be:
 
 - [ ] Support for Layouts
@@ -66,6 +53,16 @@ Soon to follow will be:
 
 ## Additional Items
 
+- [x] Port engine from Piston to SDL2
+- [x] Text Widget
+  - [x] OpenSans Font Included
+- [x] Image Widget
+- [x] Progress Bar Widget
+- [x] Timer Widget
+- [x] Push Button Widget
+- [x] Image Button Widget
+- [x] Toggle Button Widget
+- [x] Checkbox Widget
 - [x] Fix build so that it builds on TravisCI for both OSes properly
 - [x] New traits for optimization:
   - [x] `Drawable`

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -4,6 +4,9 @@
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   echo "Special build rules for OS X here"
+  brew update
+  brew upgrade
+  brew install ruby
   brew install sdl2
 fi
 

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -4,6 +4,7 @@
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   echo "Special build rules for OS X here"
+  brew install sdl2
 fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -7,7 +7,7 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   brew update
   brew upgrade
   brew install ruby
-  brew install sdl2
+  brew install sdl2 sdl2_image sdl2_ttf
 fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -9,6 +9,7 @@ fi
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
   echo "Special build rules for Linux here"
   sudo apt update -y
+  sudo apt install -y libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev
 fi
 
 echo "Building Pushrod"

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -152,9 +152,9 @@ impl Engine {
                         //                        }
                     }
 
-                    _ => {
-                        // Send event through to widget.
-                        eprintln!("Event: {:?}", event);
+                    remaining_event => {
+                        self.cache
+                            .other_event(self.current_widget_id, remaining_event);
                     }
                 }
             }

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -1,0 +1,37 @@
+// Pushrod Rendering Library
+// Extensible Layout Library
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::render::widget_cache::WidgetContainer;
+
+/// This is a structure that describes the position of a `Widget` within its `Layout`.  `X` and
+/// `Y` coordinates are not given as physical positions on the screen, rather, their position in the
+/// `Layout` matrix.
+pub struct LayoutPosition {
+    pub x: i32,
+    pub y: i32,
+}
+
+/// This is a `Layout` trait that is used by the `Engine` service, which stores a list of `Widget`s,
+/// their positions (based on matrix coordinates), and an entry point to trigger the layout compute
+/// action.
+pub trait Layout {
+    /// Adds a `Widget` by ID to the `Layout` manager, given its `LayoutPosition`, as a position
+    /// marker in the manager.
+    fn add_widget(&mut self, _widget_id: i32, _widget_position: LayoutPosition);
+
+    /// Performs a layout, applying the `WidgetContainer` list at the time, so that referenced
+    /// `Widget`s can be adjusted as necessary.
+    fn do_layout(&mut self, _widgets: &[WidgetContainer]);
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -36,3 +36,7 @@ pub mod widget_config;
 
 /// This is the caching object that stores a list of `Widget`s that the Pushrod engine manages.
 pub mod widget_cache;
+
+/// This is a layout manager description module, describing rules for `Layout` managers to be used
+/// in the system, and having `Widget`s added to them.
+pub mod layout;

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -107,7 +107,9 @@ pub trait Widget {
     /// When an `Event` is sent to the application that is not handled by the `Engine::run` loop, this
     /// method is called, sending the unhandled `Event` to the currently active `Widget`.  **This behavior
     /// is subject to change** as the `Engine::run` loop is modified to handle more `Event`s.
-    fn other_event(&mut self, _widgets: &[WidgetContainer], _event: Event) {}
+    fn other_event(&mut self, _widgets: &[WidgetContainer], _event: Event) {
+        eprintln!("Other event: {:?}", _event);
+    }
 
     /// This calls the `on_tick` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -25,8 +25,6 @@ use sdl2::event::Event;
 use sdl2::pixels::Color;
 use std::collections::HashMap;
 
-pub trait ConfigConvenience {}
-
 /// This trait is shared by all `Widget` objects that have a presence on the screen.  Functions that
 /// must be implemented are documented in the trait.
 ///

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -21,6 +21,7 @@ use crate::render::callbacks::*;
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::*;
 use crate::render::{Points, Size};
+use sdl2::event::Event;
 use sdl2::pixels::Color;
 use std::collections::HashMap;
 
@@ -102,6 +103,11 @@ pub trait Widget {
     fn tick(&mut self, _widgets: &[WidgetContainer]) {
         self.tick_callback(_widgets);
     }
+
+    /// When an `Event` is sent to the application that is not handled by the `Engine::run` loop, this
+    /// method is called, sending the unhandled `Event` to the currently active `Widget`.  **This behavior
+    /// is subject to change** as the `Engine::run` loop is modified to handle more `Event`s.
+    fn other_event(&mut self, _widgets: &[WidgetContainer], _event: Event) {}
 
     /// This calls the `on_tick` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish

--- a/src/render/widget_cache.rs
+++ b/src/render/widget_cache.rs
@@ -17,6 +17,7 @@ use std::cell::RefCell;
 
 use crate::render::widget::Widget;
 use crate::render::widget_config::{CONFIG_ORIGIN, CONFIG_SIZE};
+use sdl2::event::Event;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::Canvas;
@@ -174,7 +175,7 @@ impl WidgetCache {
     /// When state is set to `true`, this indicates that a mouse button down was detected.  When set
     /// to `false`, it indicates that the mouse button was released.  When setting the button state
     /// to `widget_id == -1`, the button click message will be sent to _all_ `Widget`s, so use
-    /// `widget_id == -1` with care.
+    /// `widget_id == - 1` with care.
     pub fn button_clicked(&mut self, widget_id: i32, button: u8, clicks: u8, state: bool) {
         if widget_id == -1 {
             for i in 0..self.cache.len() {
@@ -245,6 +246,17 @@ impl WidgetCache {
             if !self.is_hidden(i as i32) {
                 self.cache[i].widget.borrow_mut().tick(&self.cache);
             }
+        }
+    }
+
+    /// This function sends all other un-handled events from SDL2 to the currently highlighted
+    /// `Widget`.
+    pub fn other_event(&mut self, widget_id: i32, event: Event) {
+        if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
+            self.cache[widget_id as usize]
+                .widget
+                .borrow_mut()
+                .other_event(&self.cache, event);
         }
     }
 

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -33,7 +33,7 @@ use std::collections::HashMap;
 pub type OnToggleCallbackType =
     Option<Box<dyn FnMut(&mut CheckboxWidget, &[WidgetContainer], bool)>>;
 
-/// This is the storage object for the `ToggleButtonWidget`.  It stores the config, properties, callback registry.
+/// This is the storage object for the `CheckboxWidget`.  It stores the config, properties, callback registry.
 pub struct CheckboxWidget {
     config: WidgetConfig,
     system_properties: HashMap<i32, String>,
@@ -47,12 +47,12 @@ pub struct CheckboxWidget {
     on_toggle: OnToggleCallbackType,
 }
 
-/// This is the implementation of the `ToggleButtonWidget` that draws a button on the screen that can be
+/// This is the implementation of the `CheckboxWidget` that draws a button on the screen that can be
 /// toggled on or off.
 impl CheckboxWidget {
-    /// Creates a new `ToggleButtonWidget` given the `x, y, w, h` coordinates, the `text` to display
+    /// Creates a new `CheckboxWidget` given the `x, y, w, h` coordinates, the `text` to display
     /// inside the button, `font_size` of the font to display, and the initial `selected` state: `true`
-    /// being selected, `false` otherwise.
+    /// being checked, `false` otherwise.
     pub fn new(
         x: i32,
         y: i32,
@@ -135,7 +135,7 @@ impl CheckboxWidget {
     }
 }
 
-/// This is the `Widget` implementation of the `ToggleButtonWidget`.
+/// This is the `Widget` implementation of the `CheckboxWidget`.
 impl Widget for CheckboxWidget {
     /// Draws the `CheckboxWidget` contents.
     fn draw(&mut self, c: &mut Canvas<Window>) {

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -74,12 +74,6 @@ impl CheckboxWidget {
             h - 4,
         );
 
-        let text_color = if selected {
-            Color::RGB(255, 255, 255)
-        } else {
-            Color::RGB(0, 0, 0)
-        };
-
         let mut config = WidgetConfig::new(x, y, w, h);
         let mut unchecked_widget = ImageWidget::new(
             String::from("assets/checkbox_unselected.png"),
@@ -148,14 +142,14 @@ impl Widget for CheckboxWidget {
                 } else {
                     self.checked_widget.draw(c);
                 }
-            } else {
+            } else if !self.in_bounds {
                 if self.selected {
                     self.checked_widget.draw(c);
                 } else {
                     self.unchecked_widget.draw(c);
                 }
             }
-        } else {
+        } else if !self.active {
             if self.selected {
                 self.checked_widget.draw(c);
             } else {

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -48,7 +48,10 @@ pub struct ImageButtonWidget {
     on_click: OnClickCallbackType,
 }
 
+/// This is the implementation of the `ImageButtonWidget`, which displays an image next to some text.
 impl ImageButtonWidget {
+    /// Creates a new `ImageButtonWidget`, given the `x, y, w, h` coordinates, a block of `text`, the
+    /// `font_size` to use, and the `image_name` to load and display.
     pub fn new(
         x: i32,
         y: i32,

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -16,10 +16,7 @@
 use crate::render::callbacks::CallbackRegistry;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::widget_config::{
-    WidgetConfig, CONFIG_BORDER_WIDTH, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER, CONFIG_COLOR_TEXT,
-    CONFIG_IMAGE_POSITION,
-};
+use crate::render::widget_config::*;
 use crate::render::Points;
 
 use sdl2::render::Canvas;

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -44,7 +44,12 @@ pub struct PushButtonWidget {
     on_click: OnClickCallbackType,
 }
 
+/// This is the `PushButtonWidget` implementation, which displays a block of text inside a clickable
+/// box.  Clicking the box will cause an `on_click` callback to be triggered, which will call a block
+/// of text, if the callback has been configured.
 impl PushButtonWidget {
+    /// Creates a new `PushButtonWidget`, given `x, y, w, h` coordinates, some `text` to display,
+    /// and the `font_size` to use.
     pub fn new(x: i32, y: i32, w: u32, h: u32, text: String, font_size: i32) -> Self {
         let mut base_widget = BaseWidget::new(x, y, w, h);
         let mut text_widget = TextWidget::new(

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -139,20 +139,18 @@ impl Widget for TextWidget {
         match _k {
             CONFIG_COLOR_TEXT => self.get_config().set_invalidate(true),
             CONFIG_COLOR_BASE => self.get_config().set_invalidate(true),
-            CONFIG_FONT_SIZE => match _v {
-                Config::Numeric(size) => {
+            CONFIG_FONT_SIZE => {
+                if let Config::Numeric(size) = _v {
                     self.font_size = size;
                     self.get_config().set_invalidate(true);
                 }
-                _ => (),
-            },
-            CONFIG_TEXT => match _v {
-                Config::Text(text) => {
+            }
+            CONFIG_TEXT => {
+                if let Config::Text(text) = _v {
                     self.msg = text.clone();
                     self.get_config().set_invalidate(true);
                 }
-                _ => (),
-            },
+            }
 
             _ => (),
         };

--- a/src/widgets/timer_widget.rs
+++ b/src/widgets/timer_widget.rs
@@ -21,8 +21,11 @@ use crate::render::widget_config::WidgetConfig;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// This is the callback type that is used when an `on_timeout` callback is triggered from this
+/// `Widget`.
 pub type TimerCallbackType = Option<Box<dyn FnMut(&mut TimerWidget, &[WidgetContainer])>>;
 
+/// Private function used to return the current time in milliseconds.
 fn time_ms() -> u64 {
     let since_the_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
 


### PR DESCRIPTION
- Documentation improvements
- Clippy code improvements
- Changed build process to load in Ubuntu libraries for SDL2 build
- Updated Ubuntu documentation thanks to @alexislozano
- Added handler for all other events in a catch-all function for `Widget`s (#227)
- Fixed travis-ci build for OS X builds
- Modified `Widget`s so that they display the events sent to them that are unhandled.
- Added `Layout` class, back ported from the original class, greatly simplified. (#230)
