### PR TITLE
0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `POINT_X, POINT_Y` and `SIZE_WIDTH, SIZE_HEIGHT` `usize` constants for `Points` and `Size` types.
 - Added `PaddingConstraint` struct.
 - Added `CONFIG_PADDING` option to `WidgetConfig` class.
+- Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied.
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Pushrod Change Log
 
+## 0.4.14
+
+
+
 ## 0.4.13
 
 - Documentation improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `default_widget_functions` macro to inject default functions for `Widget` structs. (#235)
 - Removed config options from ProgressWidget, now uses `set_progress` to set the progress values.
 - Added `get_progress` to ProgressWidget
+- Modified `timer` test to use downcast_mut on casted object for callback.
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied. (#235)
 - Added `default_widget_functions` macro to inject default functions for `Widget` structs. (#235)
 - Removed config options from ProgressWidget, now uses `set_progress` to set the progress values.
+- Added `get_progress` to ProgressWidget
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Added `POINT_X, POINT_Y` and `SIZE_WIDTH, SIZE_HEIGHT` `usize` constants for `Points` and `Size` types.
 - Added `PaddingConstraint` struct.
 - Added `CONFIG_PADDING` option to `WidgetConfig` class.
-- Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied.
+- Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied. (#235)
+- Added `default_widget_functions` macro to inject default functions for `Widget` structs. (#235)
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added `HorizontalLayout` manager (#228)
 - Added `POINT_X, POINT_Y` and `SIZE_WIDTH, SIZE_HEIGHT` `usize` constants for `Points` and `Size` types.
+- Added `PaddingConstraint` struct.
+- Added `CONFIG_PADDING` option to `WidgetConfig` class.
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.14
 
+- Added `HorizontalLayout` manager (#228)
+- Added `POINT_X, POINT_Y` and `SIZE_WIDTH, SIZE_HEIGHT` `usize` constants for `Points` and `Size` types.
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.4.14
 
 
-
 ## 0.4.13
 
 - Documentation improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added `get_progress` to ProgressWidget
 - Modified `timer` test to use downcast_mut on casted object for callback.
 - Added `cast!` macro that casts `WidgetContainer` object to specified `Widget` type, used in examples. (#236)
+- Added extra functions to get/set padding (#233)
+- Added invalidated flag to layout as `needs_layout` function (#237)
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed config options from ProgressWidget, now uses `set_progress` to set the progress values.
 - Added `get_progress` to ProgressWidget
 - Modified `timer` test to use downcast_mut on casted object for callback.
+- Added `cast!` macro that casts `WidgetContainer` object to specified `Widget` type, used in examples. (#236)
 
 ## 0.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `CONFIG_PADDING` option to `WidgetConfig` class.
 - Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied. (#235)
 - Added `default_widget_functions` macro to inject default functions for `Widget` structs. (#235)
+- Removed config options from ProgressWidget, now uses `set_progress` to set the progress values.
 
 ## 0.4.13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.4.13"
+version = "0.4.14"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_PROGRESS};
+use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY};
 use pushrod::widgets::progress_widget::*;
 use sdl2::pixels::Color;
 
@@ -17,20 +17,17 @@ pub fn main() {
         .build()
         .unwrap();
     let mut engine = Engine::new();
-    let mut widget1 = ProgressWidget::new(20, 20, 360, 40);
+    let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget1.set_numeric(CONFIG_PROGRESS, 25);
 
-    let mut widget2 = ProgressWidget::new(20, 70, 360, 40);
+    let mut widget2 = ProgressWidget::new(20, 70, 360, 40, 50);
 
     widget2.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget2.set_numeric(CONFIG_PROGRESS, 50);
 
-    let mut widget3 = ProgressWidget::new(20, 120, 360, 40);
+    let mut widget3 = ProgressWidget::new(20, 120, 360, 40, 75);
 
     widget3.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget3.set_numeric(CONFIG_PROGRESS, 75);
 
     engine.setup(500, 180);
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY};
+use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::progress_widget::*;
 use sdl2::pixels::Color;
 

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -4,7 +4,7 @@ extern crate sdl2;
 use pushrod::render::callbacks::widget_id_for_name;
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY};
+use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
@@ -38,24 +38,24 @@ pub fn main() {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));
-//        let timer1_pos = (_widgets[widget1_id]
-//            .widget
-//            .borrow_mut()
-//            .get_numeric(CONFIG_PROGRESS)
-//            + 1)
-//            % 100;
-//        let timer2_pos = (_widgets[widget2_id]
-//            .widget
-//            .borrow_mut()
-//            .get_numeric(CONFIG_PROGRESS)
-//            + 1)
-//            % 100;
-//        let timer3_pos = (_widgets[widget3_id]
-//            .widget
-//            .borrow_mut()
-//            .get_numeric(CONFIG_PROGRESS)
-//            + 1)
-//            % 100;
+        //        let timer1_pos = (_widgets[widget1_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .get_numeric(CONFIG_PROGRESS)
+        //            + 1)
+        //            % 100;
+        //        let timer2_pos = (_widgets[widget2_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .get_numeric(CONFIG_PROGRESS)
+        //            + 1)
+        //            % 100;
+        //        let timer3_pos = (_widgets[widget3_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .get_numeric(CONFIG_PROGRESS)
+        //            + 1)
+        //            % 100;
 
         eprintln!(
             "{}",
@@ -66,18 +66,18 @@ pub fn main() {
                 .is::<ProgressWidget>()
         );
 
-//        _widgets[widget1_id]
-//            .widget
-//            .borrow_mut()
-//            .set_numeric(CONFIG_PROGRESS, timer1_pos);
-//        _widgets[widget2_id]
-//            .widget
-//            .borrow_mut()
-//            .set_numeric(CONFIG_PROGRESS, timer2_pos);
-//        _widgets[widget3_id]
-//            .widget
-//            .borrow_mut()
-//            .set_numeric(CONFIG_PROGRESS, timer3_pos);
+        //        _widgets[widget1_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .set_numeric(CONFIG_PROGRESS, timer1_pos);
+        //        _widgets[widget2_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .set_numeric(CONFIG_PROGRESS, timer2_pos);
+        //        _widgets[widget3_id]
+        //            .widget
+        //            .borrow_mut()
+        //            .set_numeric(CONFIG_PROGRESS, timer3_pos);
     });
 
     engine.setup(500, 180);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -6,10 +6,10 @@ use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
 use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_PROGRESS};
 use pushrod::widgets::progress_widget::*;
+use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
 use sdl2::pixels::Color;
 use std::any::Any;
-use pushrod::widgets::text_widget::TextWidget;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
@@ -60,7 +60,14 @@ pub fn main() {
             + 1)
             % 100;
 
-        eprintln!("{}", _widgets[widget1_id].widget.borrow_mut().as_any().is::<ProgressWidget>());
+        eprintln!(
+            "{}",
+            _widgets[widget1_id]
+                .widget
+                .borrow_mut()
+                .as_any()
+                .is::<ProgressWidget>()
+        );
 
         _widgets[widget1_id]
             .widget

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -4,11 +4,11 @@ extern crate sdl2;
 use pushrod::render::callbacks::widget_id_for_name;
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
+use pushrod::render::widget::*;
 use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
-use pushrod::render::widget::*;
 use sdl2::pixels::Color;
 use std::any::Any;
 
@@ -17,12 +17,12 @@ use std::any::Any;
 macro_rules! cast {
     ($a:expr, $b:expr, $c:ident) => {
         $a[$b]
-        .widget
-        .borrow_mut()
-        .as_any()
-        .downcast_mut::<$c>()
-        .unwrap()
-    }
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<$c>()
+            .unwrap()
+    };
 }
 
 pub fn main() {
@@ -52,18 +52,12 @@ pub fn main() {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));
-        let progress1_value: u8 = (cast!(_widgets, widget1_id, ProgressWidget)
-            .get_progress()
-            + 1)
-            % 100;
-        let progress2_value: u8 = (cast!(_widgets, widget2_id, ProgressWidget)
-            .get_progress()
-            + 1)
-            % 100;
-        let progress3_value: u8 = (cast!(_widgets, widget3_id, ProgressWidget)
-            .get_progress()
-            + 1)
-            % 100;
+        let progress1_value: u8 =
+            (cast!(_widgets, widget1_id, ProgressWidget).get_progress() + 1) % 100;
+        let progress2_value: u8 =
+            (cast!(_widgets, widget2_id, ProgressWidget).get_progress() + 1) % 100;
+        let progress3_value: u8 =
+            (cast!(_widgets, widget3_id, ProgressWidget).get_progress() + 1) % 100;
 
         cast!(_widgets, widget1_id, ProgressWidget).set_progress(progress1_value);
         cast!(_widgets, widget2_id, ProgressWidget).set_progress(progress2_value);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -8,6 +8,8 @@ use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_PROGRESS};
 use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::timer_widget::*;
 use sdl2::pixels::Color;
+use std::any::Any;
+use pushrod::widgets::text_widget::TextWidget;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
@@ -57,6 +59,8 @@ pub fn main() {
             .get_numeric(CONFIG_PROGRESS)
             + 1)
             % 100;
+
+        eprintln!("{}", _widgets[widget1_id].widget.borrow_mut().as_any().is::<ProgressWidget>());
 
         _widgets[widget1_id]
             .widget

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -4,7 +4,7 @@ extern crate sdl2;
 use pushrod::render::callbacks::widget_id_for_name;
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_PROGRESS};
+use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY};
 use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
@@ -21,44 +21,41 @@ pub fn main() {
         .build()
         .unwrap();
     let mut engine = Engine::new();
-    let mut widget1 = ProgressWidget::new(20, 20, 360, 40);
+    let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget1.set_numeric(CONFIG_PROGRESS, 25);
 
-    let mut widget2 = ProgressWidget::new(20, 70, 360, 40);
+    let mut widget2 = ProgressWidget::new(20, 70, 360, 40, 50);
 
     widget2.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget2.set_numeric(CONFIG_PROGRESS, 50);
 
-    let mut widget3 = ProgressWidget::new(20, 120, 360, 40);
+    let mut widget3 = ProgressWidget::new(20, 120, 360, 40, 75);
 
     widget3.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-    widget3.set_numeric(CONFIG_PROGRESS, 75);
 
     let mut timer = TimerWidget::new(100, true);
     timer.on_timeout(|x, _widgets| {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));
-        let timer1_pos = (_widgets[widget1_id]
-            .widget
-            .borrow_mut()
-            .get_numeric(CONFIG_PROGRESS)
-            + 1)
-            % 100;
-        let timer2_pos = (_widgets[widget2_id]
-            .widget
-            .borrow_mut()
-            .get_numeric(CONFIG_PROGRESS)
-            + 1)
-            % 100;
-        let timer3_pos = (_widgets[widget3_id]
-            .widget
-            .borrow_mut()
-            .get_numeric(CONFIG_PROGRESS)
-            + 1)
-            % 100;
+//        let timer1_pos = (_widgets[widget1_id]
+//            .widget
+//            .borrow_mut()
+//            .get_numeric(CONFIG_PROGRESS)
+//            + 1)
+//            % 100;
+//        let timer2_pos = (_widgets[widget2_id]
+//            .widget
+//            .borrow_mut()
+//            .get_numeric(CONFIG_PROGRESS)
+//            + 1)
+//            % 100;
+//        let timer3_pos = (_widgets[widget3_id]
+//            .widget
+//            .borrow_mut()
+//            .get_numeric(CONFIG_PROGRESS)
+//            + 1)
+//            % 100;
 
         eprintln!(
             "{}",
@@ -69,18 +66,18 @@ pub fn main() {
                 .is::<ProgressWidget>()
         );
 
-        _widgets[widget1_id]
-            .widget
-            .borrow_mut()
-            .set_numeric(CONFIG_PROGRESS, timer1_pos);
-        _widgets[widget2_id]
-            .widget
-            .borrow_mut()
-            .set_numeric(CONFIG_PROGRESS, timer2_pos);
-        _widgets[widget3_id]
-            .widget
-            .borrow_mut()
-            .set_numeric(CONFIG_PROGRESS, timer3_pos);
+//        _widgets[widget1_id]
+//            .widget
+//            .borrow_mut()
+//            .set_numeric(CONFIG_PROGRESS, timer1_pos);
+//        _widgets[widget2_id]
+//            .widget
+//            .borrow_mut()
+//            .set_numeric(CONFIG_PROGRESS, timer2_pos);
+//        _widgets[widget3_id]
+//            .widget
+//            .borrow_mut()
+//            .set_numeric(CONFIG_PROGRESS, timer3_pos);
     });
 
     engine.setup(500, 180);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -8,8 +8,22 @@ use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
+use pushrod::render::widget::*;
 use sdl2::pixels::Color;
 use std::any::Any;
+
+#[macro_export]
+
+macro_rules! cast {
+    ($a:expr, $b:expr, $c:ident) => {
+        $a[$b]
+        .widget
+        .borrow_mut()
+        .as_any()
+        .downcast_mut::<$c>()
+        .unwrap()
+    }
+}
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
@@ -38,55 +52,22 @@ pub fn main() {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));
-        let progress1_value: u8 = (_widgets[widget1_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
+        let progress1_value: u8 = (cast!(_widgets, widget1_id, ProgressWidget)
             .get_progress()
             + 1)
             % 100;
-        let progress2_value: u8 = (_widgets[widget2_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
+        let progress2_value: u8 = (cast!(_widgets, widget2_id, ProgressWidget)
             .get_progress()
             + 1)
             % 100;
-        let progress3_value: u8 = (_widgets[widget3_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
+        let progress3_value: u8 = (cast!(_widgets, widget3_id, ProgressWidget)
             .get_progress()
             + 1)
             % 100;
 
-        _widgets[widget1_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
-            .set_progress(progress1_value);
-        _widgets[widget2_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
-            .set_progress(progress2_value);
-        _widgets[widget3_id]
-            .widget
-            .borrow_mut()
-            .as_any()
-            .downcast_mut::<ProgressWidget>()
-            .unwrap()
-            .set_progress(progress3_value);
+        cast!(_widgets, widget1_id, ProgressWidget).set_progress(progress1_value);
+        cast!(_widgets, widget2_id, ProgressWidget).set_progress(progress2_value);
+        cast!(_widgets, widget3_id, ProgressWidget).set_progress(progress3_value);
     });
 
     engine.setup(500, 180);

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -38,46 +38,55 @@ pub fn main() {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));
-        //        let timer1_pos = (_widgets[widget1_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .get_numeric(CONFIG_PROGRESS)
-        //            + 1)
-        //            % 100;
-        //        let timer2_pos = (_widgets[widget2_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .get_numeric(CONFIG_PROGRESS)
-        //            + 1)
-        //            % 100;
-        //        let timer3_pos = (_widgets[widget3_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .get_numeric(CONFIG_PROGRESS)
-        //            + 1)
-        //            % 100;
+        let progress1_value: u8 = (_widgets[widget1_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .get_progress()
+            + 1)
+            % 100;
+        let progress2_value: u8 = (_widgets[widget2_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .get_progress()
+            + 1)
+            % 100;
+        let progress3_value: u8 = (_widgets[widget3_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .get_progress()
+            + 1)
+            % 100;
 
-        eprintln!(
-            "{}",
-            _widgets[widget1_id]
-                .widget
-                .borrow_mut()
-                .as_any()
-                .is::<ProgressWidget>()
-        );
-
-        //        _widgets[widget1_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .set_numeric(CONFIG_PROGRESS, timer1_pos);
-        //        _widgets[widget2_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .set_numeric(CONFIG_PROGRESS, timer2_pos);
-        //        _widgets[widget3_id]
-        //            .widget
-        //            .borrow_mut()
-        //            .set_numeric(CONFIG_PROGRESS, timer3_pos);
+        _widgets[widget1_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .set_progress(progress1_value);
+        _widgets[widget2_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .set_progress(progress2_value);
+        _widgets[widget3_id]
+            .widget
+            .borrow_mut()
+            .as_any()
+            .downcast_mut::<ProgressWidget>()
+            .unwrap()
+            .set_progress(progress3_value);
     });
 
     engine.setup(500, 180);

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -17,6 +17,7 @@ use crate::render::layout::{Layout, LayoutPosition};
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::CONFIG_SIZE;
 use crate::render::{Points, Size, SIZE_HEIGHT, SIZE_WIDTH};
+use std::any::Any;
 
 /// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.
 pub struct HorizontalLayout {

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::render::layout::{Layout, LayoutPosition};
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::layout::{LayoutPosition, Layout};
-use crate::render::{Points, Size};
+use crate::render::widget_config::CONFIG_SIZE;
+use crate::render::{Points, Size, SIZE_HEIGHT, SIZE_WIDTH};
 
 /// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.
 pub struct HorizontalLayout {
@@ -54,21 +55,48 @@ impl Layout for HorizontalLayout {
         }
 
         let num_widgets = self.widget_ids.len() as u32;
-        let widget_width = self.size[0] / num_widgets as u32;
+        let widget_width = self.size[SIZE_WIDTH] / num_widgets as u32;
         let subtractor_right = self.spacing / 2;
         let subtractor_left = subtractor_right - 1;
 
+        eprintln!(
+            "HorizontalLayout: rightside={} leftside={}",
+            subtractor_right, subtractor_left
+        );
+
         for i in 0..num_widgets {
+            let set_x: i32;
+            let mut set_width: u32 = widget_width;
+            let widget_id = self.widget_ids[i as usize];
+
             if i == 0 {
-                // skip subtractor left
-                // apply only subtractor right
+                set_x = (i * set_width) as i32;
+                set_width = widget_width - subtractor_right;
             } else if i == num_widgets - 1 {
-                // skip subtractor right
-                // apply only subtractor left
+                set_x = (i * set_width) as i32 - subtractor_left as i32;
+                set_width = widget_width - subtractor_left;
             } else {
-                // apply subtractor left
-                // apply subtractor right
+                set_x = (i * set_width) as i32 - subtractor_left as i32;
+                set_width = widget_width - subtractor_left - subtractor_right;
             }
+
+            _widgets[widget_id as usize]
+                .widget
+                .borrow_mut()
+                .get_config()
+                .to_x(set_x);
+
+            let widget_size = _widgets[widget_id as usize]
+                .widget
+                .borrow_mut()
+                .get_config()
+                .get_size(CONFIG_SIZE);
+
+            _widgets[widget_id as usize]
+                .widget
+                .borrow_mut()
+                .get_config()
+                .set_size(CONFIG_SIZE, set_width, self.size[SIZE_HEIGHT]);
         }
     }
 }

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -17,7 +17,6 @@ use crate::render::layout::{Layout, LayoutPosition};
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::CONFIG_SIZE;
 use crate::render::{Points, Size, SIZE_HEIGHT, SIZE_WIDTH};
-use std::any::Any;
 
 /// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.
 pub struct HorizontalLayout {

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -1,0 +1,74 @@
+// Pushrod Rendering Library
+// Horizontal Layout Manager
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::render::widget_cache::WidgetContainer;
+use crate::render::layout::{LayoutPosition, Layout};
+use crate::render::{Points, Size};
+
+/// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.
+pub struct HorizontalLayout {
+    widget_ids: Vec<i32>,
+    widget_positions: Vec<LayoutPosition>,
+    origin: Points,
+    size: Size,
+    spacing: u32,
+}
+
+/// Creates a new `HorizontalLayout` manager.
+impl HorizontalLayout {
+    pub fn new(x: i32, y: i32, w: u32, h: u32, spacing: u32) -> Self {
+        Self {
+            widget_ids: Vec::new(),
+            widget_positions: Vec::new(),
+            origin: vec![x, y],
+            size: vec![w, h],
+            spacing,
+        }
+    }
+}
+
+/// This is the `Layout` implementation for the `HorizontalLayout` manager.
+impl Layout for HorizontalLayout {
+    /// Adds a widget to the `HorizontalLayout` managed stack.
+    fn add_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
+        self.widget_ids.push(widget_id);
+        self.widget_positions.push(widget_position);
+    }
+
+    /// Adjusts the layout of the `Widget`s managed by this `Layout` manager.
+    fn do_layout(&mut self, _widgets: &[WidgetContainer]) {
+        if self.widget_ids.len() <= 1 {
+            return;
+        }
+
+        let num_widgets = self.widget_ids.len() as u32;
+        let widget_width = self.size[0] / num_widgets as u32;
+        let subtractor_right = self.spacing / 2;
+        let subtractor_left = subtractor_right - 1;
+
+        for i in 0..num_widgets {
+            if i == 0 {
+                // skip subtractor left
+                // apply only subtractor right
+            } else if i == num_widgets - 1 {
+                // skip subtractor right
+                // apply only subtractor left
+            } else {
+                // apply subtractor left
+                // apply subtractor right
+            }
+        }
+    }
+}

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -1,0 +1,20 @@
+// Pushrod Widgets Library
+// Core Layout Managers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+
+/// This is a `HorizontalLayout` manager.  It handles the even spacing of
+/// `Widget`s in a horizontal display area.
+pub mod horizontal_layout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,17 @@ mod macros {
             }
         }
     }
+
+    macro_rules! default_widget_functions {
+        () => {
+            /// This function is a macro-created getter function that returns the `Widget`'s configuration
+            /// object as a borrowed mutable reference.  This code is auto-generated using the
+            /// `default_widget_properties!()` macro.
+            fn as_any(&mut self) -> &dyn Any {
+                self
+            }
+        }
+    }
 }
 
 /// `widgets` is a core rendering library used by `Pushrod`, containing the default set of `Widget`s.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod macros {
             /// This function is a macro-created getter function that returns the `Widget` as an `Any`
             /// type.  This allows the `Widget` trait to be downcast into a `struct` that implements
             /// the `Widget` trait.
-            fn as_any(&mut self) -> &dyn Any {
+            fn as_any(&mut self) -> &mut dyn Any {
                 self
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 /// These macros are used and shared by all components in the `Pushrod` library.
 mod macros {
     #[macro_export]
+
     /// This macro is used by `Widget` implementations, which auto-injects getter code for the
     /// `Widget`'s properties.  Since all `Widget` implementations share these functions, and must
     /// implement them locally, this `macro` serves as a quick way to implement the same reused code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,11 +141,14 @@ mod macros {
         }
     }
 
+    /// This macro implements extra functions for the `Widget` automatically.  This is a list of functions
+    /// that are not optional, and must be implemented in some form or fashion.  If you choose not to
+    /// implement your own version of the functions, use this macro to apply the functions automatically.
     macro_rules! default_widget_functions {
         () => {
-            /// This function is a macro-created getter function that returns the `Widget`'s configuration
-            /// object as a borrowed mutable reference.  This code is auto-generated using the
-            /// `default_widget_properties!()` macro.
+            /// This function is a macro-created getter function that returns the `Widget` as an `Any`
+            /// type.  This allows the `Widget` trait to be downcast into a `struct` that implements
+            /// the `Widget` trait.
             fn as_any(&mut self) -> &dyn Any {
                 self
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,3 +147,6 @@ pub mod widgets;
 
 /// `render` is the core rendering/event loop portion of `Pushrod`.
 pub mod render;
+
+/// `layouts` is the core layout managers included with `Pushrod`.
+pub mod layouts;

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use crate::render::widget_cache::WidgetContainer;
+use crate::render::widget_config::PaddingConstraint;
 
 /// This is a structure that describes the position of a `Widget` within its `Layout`.  `X` and
 /// `Y` coordinates are not given as physical positions on the screen, rather, their position in the
@@ -31,7 +32,17 @@ pub trait Layout {
     /// marker in the manager.
     fn add_widget(&mut self, _widget_id: i32, _widget_position: LayoutPosition);
 
+    /// Changes the `PaddingConstraint` for this `Layout`.
+    fn set_padding(&mut self, padding: PaddingConstraint);
+
+    /// Retrieves the current `PaddingConstraint`.
+    fn get_padding(&self) -> PaddingConstraint;
+
     /// Performs a layout, applying the `WidgetContainer` list at the time, so that referenced
     /// `Widget`s can be adjusted as necessary.
     fn do_layout(&mut self, _widgets: &[WidgetContainer]);
+
+    /// Indicates whether or not the `Layout` needs to have `do_layout` re-run.  This is generally
+    /// needed when the `LayoutPosition` changes, or when `PaddingConstraint`s change.
+    fn needs_layout(&self) -> bool;
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -16,8 +16,20 @@
 /// This is a type that defines two points: X and Y coordinates.
 pub type Points = Vec<i32>;
 
+/// Quick reference in `Points` `Vec` for X position.
+pub const POINT_X: usize = 0;
+
+/// Quick reference in `Points` `Vec` for Y position.
+pub const POINT_Y: usize = 1;
+
 /// This is a type that defines two size: width and height.
 pub type Size = Vec<u32>;
+
+/// Quick reference in `Size` `Vec` for width.
+pub const SIZE_WIDTH: usize = 0;
+
+/// Quick reference in `Size` `Vec` for height.
+pub const SIZE_HEIGHT: usize = 1;
 
 /// This is the `Engine` that is used to dispatch events from the screen to a corresponding list
 /// of `Widget`s in a `Window`.  This is the main event loop.

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -24,6 +24,7 @@ use crate::render::{Points, Size};
 use sdl2::event::Event;
 use sdl2::pixels::Color;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This trait is shared by all `Widget` objects that have a presence on the screen.  Functions that
 /// must be implemented are documented in the trait.
@@ -35,6 +36,8 @@ use std::collections::HashMap;
 /// these automatically generated implementation details could change in future releases of this
 /// library, so it is best to use the default implementation if possible.
 pub trait Widget {
+    fn as_any(&mut self) -> &dyn Any;
+
     /// Draws the widget.  If you wish to modify the canvas object, you must declare it as `mut` in
     /// your implementation (ie `fn draw(&mut self, mut canvas: Canvas<Window>)`).  The `_canvas`
     /// is the currently active drawing canvas at the time this function is called.  This called
@@ -305,6 +308,10 @@ impl Widget for BaseWidget {
                     .unwrap();
             }
         }
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -23,8 +23,8 @@ use crate::render::widget_config::*;
 use crate::render::{Points, Size};
 use sdl2::event::Event;
 use sdl2::pixels::Color;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This trait is shared by all `Widget` objects that have a presence on the screen.  Functions that
 /// must be implemented are documented in the trait.
@@ -312,9 +312,9 @@ impl Widget for BaseWidget {
         }
     }
 
-//    fn as_any(&mut self) -> &dyn Any {
-//        self
-//    }
+    //    fn as_any(&mut self) -> &dyn Any {
+    //        self
+    //    }
 
     default_widget_functions!();
     default_widget_properties!();

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -36,6 +36,8 @@ use std::any::Any;
 /// these automatically generated implementation details could change in future releases of this
 /// library, so it is best to use the default implementation if possible.
 pub trait Widget {
+    /// Retrieves this `Widget` as an `Any` object so that it can be downcast using `downcast_ref`
+    /// to a `struct` that implements the `Widget` trait.
     fn as_any(&mut self) -> &dyn Any;
 
     /// Draws the widget.  If you wish to modify the canvas object, you must declare it as `mut` in
@@ -310,10 +312,11 @@ impl Widget for BaseWidget {
         }
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
+//    fn as_any(&mut self) -> &dyn Any {
+//        self
+//    }
 
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 pub trait Widget {
     /// Retrieves this `Widget` as an `Any` object so that it can be downcast using `downcast_ref`
     /// to a `struct` that implements the `Widget` trait.
-    fn as_any(&mut self) -> &dyn Any;
+    fn as_any(&mut self) -> &mut dyn Any;
 
     /// Draws the widget.  If you wish to modify the canvas object, you must declare it as `mut` in
     /// your implementation (ie `fn draw(&mut self, mut canvas: Canvas<Window>)`).  The `_canvas`

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -312,10 +312,6 @@ impl Widget for BaseWidget {
         }
     }
 
-    //    fn as_any(&mut self) -> &dyn Any {
-    //        self
-    //    }
-
     default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();

--- a/src/render/widget_config.rs
+++ b/src/render/widget_config.rs
@@ -60,9 +60,6 @@ pub const CONFIG_BORDER_WIDTH: u8 = 8;
 /// value.
 pub const CONFIG_TEXT: u8 = 9;
 
-/// `Widget` progress value store.  This is stored as a `Config::Numeric` value.
-pub const CONFIG_PROGRESS: u8 = 10;
-
 /// `Widget` image position direction, controls the position of an `Image` within the bounds of a
 /// `Widget`.  This is stored as a `Config::CompassPosition` value.
 pub const CONFIG_IMAGE_POSITION: u8 = 11;

--- a/src/render/widget_config.rs
+++ b/src/render/widget_config.rs
@@ -73,6 +73,10 @@ pub const CONFIG_FONT_SIZE: u8 = 12;
 /// `PushButtonWidget` selected state.  This is stored as a `Config::Toggle` value.
 pub const CONFIG_SELECTED_STATE: u8 = 13;
 
+/// `PaddingConstraint` that can be applied to a `Widget` or a `Layout`.  This is stored as a
+/// `Config::PaddingConstraint` value.
+pub const CONFIG_PADDING: u8 = 14;
+
 /// This enum is used by the `ImageWidget`, which controls the positioning of the image being
 /// rendered within the bounds of the `Widget`.
 #[derive(Clone, Debug)]
@@ -105,6 +109,16 @@ pub enum CompassPosition {
     SE,
 }
 
+/// This struct stores padding constraints.
+#[derive(Clone, Default, Debug)]
+pub struct PaddingConstraint {
+    pub top: i32,
+    pub bottom: i32,
+    pub left: i32,
+    pub right: i32,
+    pub spacing: i32,
+}
+
 /// Configuration object type - allows configurations to be set using `Piston`, `Pushrod`, or
 /// native types.
 #[derive(Clone, Debug)]
@@ -129,6 +143,9 @@ pub enum Config {
 
     /// This stores a `ComapssPosition`.
     CompassPosition(CompassPosition),
+
+    /// This stores a `PaddingConstraint`.
+    PaddingConstraint(PaddingConstraint),
 }
 
 /// This is the store for the `WidgetConfig`, which each `Widget` object needs.  This stores
@@ -270,6 +287,11 @@ impl WidgetConfig {
         self.config.insert(config, Config::CompassPosition(value));
     }
 
+    /// Applies a `PaddingConstraint`.
+    pub fn set_padding(&mut self, config: u8, value: PaddingConstraint) {
+        self.config.insert(config, Config::PaddingConstraint(value));
+    }
+
     /// Retrieves a `Points` for a configuration key.  Returns `Points::default` if not set.
     pub fn get_point(&self, k: u8) -> Points {
         match self.config.get(&k) {
@@ -323,6 +345,14 @@ impl WidgetConfig {
         match self.config.get(&k) {
             Some(Config::CompassPosition(position)) => position.clone(),
             _ => CompassPosition::W,
+        }
+    }
+
+    /// Retrieves a `PaddingConstraint` toggle for a configuration key.  Returns empty `PaddingConstraint` if not set.
+    pub fn get_padding(&self, k: u8) -> PaddingConstraint {
+        match self.config.get(&k) {
+            Some(Config::PaddingConstraint(constraint)) => constraint.clone(),
+            _ => PaddingConstraint::default(),
         }
     }
 }

--- a/src/render/widget_config.rs
+++ b/src/render/widget_config.rs
@@ -70,10 +70,6 @@ pub const CONFIG_FONT_SIZE: u8 = 12;
 /// `PushButtonWidget` selected state.  This is stored as a `Config::Toggle` value.
 pub const CONFIG_SELECTED_STATE: u8 = 13;
 
-/// `PaddingConstraint` that can be applied to a `Widget` or a `Layout`.  This is stored as a
-/// `Config::PaddingConstraint` value.
-pub const CONFIG_PADDING: u8 = 14;
-
 /// This enum is used by the `ImageWidget`, which controls the positioning of the image being
 /// rendered within the bounds of the `Widget`.
 #[derive(Clone, Debug)]

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -202,10 +202,7 @@ impl Widget for CheckboxWidget {
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -27,6 +27,7 @@ use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.
@@ -199,6 +200,10 @@ impl Widget for CheckboxWidget {
         }
 
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -26,8 +26,8 @@ use crate::render::widget_config::CompassPosition::Center;
 use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -27,6 +27,7 @@ use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
@@ -192,6 +193,10 @@ impl Widget for ImageButtonWidget {
         }
 
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -26,8 +26,8 @@ use crate::render::widget_config::CompassPosition::Center;
 use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -195,10 +195,7 @@ impl Widget for ImageButtonWidget {
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/image_widget.rs
+++ b/src/widgets/image_widget.rs
@@ -136,10 +136,7 @@ impl Widget for ImageWidget {
         }
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/image_widget.rs
+++ b/src/widgets/image_widget.rs
@@ -26,9 +26,9 @@ use sdl2::rect::Rect;
 use sdl2::render::{Canvas, TextureQuery};
 use sdl2::video::Window;
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::path::Path;
-use std::any::Any;
 
 /// This is the storage object for the `TextWidget`.  It stores the config, properties, callback registry,
 /// the font name, style, size, justification, and text message.

--- a/src/widgets/image_widget.rs
+++ b/src/widgets/image_widget.rs
@@ -28,6 +28,7 @@ use sdl2::video::Window;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::any::Any;
 
 /// This is the storage object for the `TextWidget`.  It stores the config, properties, callback registry,
 /// the font name, style, size, justification, and text message.
@@ -133,6 +134,10 @@ impl Widget for ImageWidget {
         if _k == CONFIG_IMAGE_POSITION {
             self.get_config().set_invalidate(true);
         }
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -93,8 +93,6 @@ impl Widget for ProgressWidget {
         let progress_width =
             (f64::from(self.get_size(CONFIG_SIZE)[0]) * (f64::from(self.progress)) / 100.0) as u32;
 
-        eprintln!("{:?}", progress_width);
-
         c.set_draw_color(base_color);
         c.fill_rect(Rect::new(
             self.config.to_x(1),

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -76,6 +76,11 @@ impl ProgressWidget {
 
         self.get_config().set_invalidate(true);
     }
+
+    /// Retrieves the current progress value as a `u8` value.
+    pub fn get_progress(&mut self) -> u8 {
+        self.progress
+    }
 }
 
 /// This is the `Widget` implementation of the `ProgressWidget`.  It contains a `BaseWidget` within
@@ -85,8 +90,8 @@ impl Widget for ProgressWidget {
         self.base_widget.draw(c);
 
         let base_color = self.get_color(CONFIG_COLOR_SECONDARY);
-        let progress_width = (f64::from(self.get_size(CONFIG_SIZE)[0])
-            * (f64::from(self.progress)) / 100.0) as u32;
+        let progress_width =
+            (f64::from(self.get_size(CONFIG_SIZE)[0]) * (f64::from(self.progress)) / 100.0) as u32;
 
         eprintln!("{:?}", progress_width);
 

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -25,6 +25,7 @@ use sdl2::video::Window;
 
 use sdl2::render::Canvas;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This is the storage object for the `ProgressWidget`.  It stores the config, properties, callback registry,
 /// the base widget, and progress from 0 to 100.
@@ -89,6 +90,11 @@ impl Widget for ProgressWidget {
             self.get_config().set_invalidate(true);
         }
     }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
+    }
+
 
     default_widget_properties!();
     default_widget_callbacks!();

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -91,11 +91,7 @@ impl Widget for ProgressWidget {
         }
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -24,8 +24,8 @@ use sdl2::rect::Rect;
 use sdl2::video::Window;
 
 use sdl2::render::Canvas;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This is the storage object for the `ProgressWidget`.  It stores the config, properties, callback registry,
 /// the base widget, and progress from 0 to 100.

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -27,6 +27,7 @@ use sdl2::video::Window;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
@@ -184,6 +185,10 @@ impl Widget for PushButtonWidget {
         }
 
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -187,10 +187,7 @@ impl Widget for PushButtonWidget {
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -26,8 +26,8 @@ use sdl2::video::Window;
 
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -157,10 +157,7 @@ impl Widget for TextWidget {
         };
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -24,9 +24,9 @@ use sdl2::ttf::FontStyle;
 use sdl2::video::Window;
 
 use sdl2::rect::Rect;
+use std::any::Any;
 use std::collections::HashMap;
 use std::path::Path;
-use std::any::Any;
 
 /// This enum is used by the `TextWidget`, which controls the justification of the text being
 /// rendered within the bounds of the `Widget`.

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -26,6 +26,7 @@ use sdl2::video::Window;
 use sdl2::rect::Rect;
 use std::collections::HashMap;
 use std::path::Path;
+use std::any::Any;
 
 /// This enum is used by the `TextWidget`, which controls the justification of the text being
 /// rendered within the bounds of the `Widget`.
@@ -154,6 +155,10 @@ impl Widget for TextWidget {
 
             _ => (),
         };
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/timer_widget.rs
+++ b/src/widgets/timer_widget.rs
@@ -18,9 +18,9 @@ use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::WidgetConfig;
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::any::Any;
 
 /// This is the callback type that is used when an `on_timeout` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/timer_widget.rs
+++ b/src/widgets/timer_widget.rs
@@ -114,9 +114,6 @@ impl Widget for TimerWidget {
         }
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
 }

--- a/src/widgets/timer_widget.rs
+++ b/src/widgets/timer_widget.rs
@@ -20,6 +20,7 @@ use crate::render::widget_config::WidgetConfig;
 
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::any::Any;
 
 /// This is the callback type that is used when an `on_timeout` callback is triggered from this
 /// `Widget`.
@@ -111,6 +112,10 @@ impl Widget for TimerWidget {
             self.initiated = time_ms();
             self.call_timeout_callback(_widgets);
         }
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/toggle_button_widget.rs
+++ b/src/widgets/toggle_button_widget.rs
@@ -24,8 +24,8 @@ use sdl2::video::Window;
 
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
-use std::collections::HashMap;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/toggle_button_widget.rs
+++ b/src/widgets/toggle_button_widget.rs
@@ -25,6 +25,7 @@ use sdl2::video::Window;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::collections::HashMap;
+use std::any::Any;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.
@@ -216,6 +217,10 @@ impl Widget for ToggleButtonWidget {
         }
 
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
+    }
+
+    fn as_any(&mut self) -> &dyn Any {
+        self
     }
 
     default_widget_properties!();

--- a/src/widgets/toggle_button_widget.rs
+++ b/src/widgets/toggle_button_widget.rs
@@ -219,10 +219,7 @@ impl Widget for ToggleButtonWidget {
         self.button_clicked_callback(_widgets, _button, _clicks, _state);
     }
 
-    fn as_any(&mut self) -> &dyn Any {
-        self
-    }
-
+    default_widget_functions!();
     default_widget_properties!();
     default_widget_callbacks!();
 }


### PR DESCRIPTION
- Added `HorizontalLayout` manager (#228)
- Added `POINT_X, POINT_Y` and `SIZE_WIDTH, SIZE_HEIGHT` `usize` constants for `Points` and `Size` types.
- Added `PaddingConstraint` struct.
- Added `CONFIG_PADDING` option to `WidgetConfig` class.
- Added `as_any` to `Widget` classes so that they can be `downcast_ref`-applied. (#235)
- Added `default_widget_functions` macro to inject default functions for `Widget` structs. (#235)
- Removed config options from ProgressWidget, now uses `set_progress` to set the progress values.
- Added `get_progress` to ProgressWidget
- Modified `timer` test to use downcast_mut on casted object for callback.
- Added `cast!` macro that casts `WidgetContainer` object to specified `Widget` type, used in examples. (#236)
- Added extra functions to get/set padding (#233)
- Added invalidated flag to layout as `needs_layout` function (#237)
