### PR TITLE
0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Changed Engine to take `w, h` of screen size when initializing.
 - Removed `setup` method to clean that up.
 - Removed commented code from `Quit` event.
+- Added `Layout` and `LayoutCache` to the `Engine`
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Pushrod Change Log
 
+## 0.4.15
+
+
 ## 0.4.14
 
 - Added `HorizontalLayout` manager (#228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed Engine to take `w, h` of screen size when initializing.
 - Removed `setup` method to clean that up.
+- Removed commented code from `Quit` event.
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.15
 
+- Changed Engine to take `w, h` of screen size when initializing.
+- Removed `setup` method to clean that up.
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed `setup` method to clean that up.
 - Removed commented code from `Quit` event.
 - Added `Layout` and `LayoutCache` to the `Engine`
+- Modified `HorizontalLayout` so that it moves the point of origin of `Widget`s based on `Layout`'s origin.
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed commented code from `Quit` event.
 - Added `Layout` and `LayoutCache` to the `Engine`
 - Modified `HorizontalLayout` so that it moves the point of origin of `Widget`s based on `Layout`'s origin.
+- Added `horizontal_layout` test.
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - Changed Engine to take `w, h` of screen size when initializing.
 - Removed `setup` method to clean that up.
 - Removed commented code from `Quit` event.
-- Added `Layout` and `LayoutCache` to the `Engine`
+- Added `Layout` and `LayoutCache` to the `Engine` (#239)
 - Modified `HorizontalLayout` so that it moves the point of origin of `Widget`s based on `Layout`'s origin.
 - Added `horizontal_layout` test.
+- Add `get_layout_by_id` to `LayoutCache` (#240)
+- Modified `Engine` so that it handles `do_layout` as required (when `needs_layout` is set) (#232)
 
 ## 0.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `horizontal_layout` test.
 - Add `get_layout_by_id` to `LayoutCache` (#240)
 - Modified `Engine` so that it handles `do_layout` as required (when `needs_layout` is set) (#232)
+- Added `LayoutContainer` slices to callbacks (#242)
 
 ## 0.4.14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.4.14"
+version = "0.4.15"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/examples/checkbox_button.rs
+++ b/examples/checkbox_button.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 180);
     let widget1 = CheckboxWidget::new(20, 20, 360, 30, String::from(" Checkbox Item 1"), 22, false);
     let widget2 = CheckboxWidget::new(20, 70, 360, 30, String::from(" Checked Checkbox"), 22, true);
     let widget3 = CheckboxWidget::new(
@@ -28,8 +28,6 @@ pub fn main() {
         22,
         false,
     );
-
-    engine.setup(500, 180);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/horizontal_layout.rs
+++ b/examples/horizontal_layout.rs
@@ -1,0 +1,50 @@
+extern crate pushrod;
+extern crate sdl2;
+
+use pushrod::render::engine::Engine;
+use pushrod::render::widget::{Widget, BaseWidget};
+use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, PaddingConstraint, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH};
+use pushrod::widgets::progress_widget::*;
+use sdl2::pixels::Color;
+use pushrod::layouts::horizontal_layout::HorizontalLayout;
+use pushrod::render::layout::{Layout, LayoutPosition};
+
+pub fn main() {
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let window = video_subsystem
+        .window("pushrod-render horizontal layout demo", 400, 180)
+        .position_centered()
+        .opengl()
+        .build()
+        .unwrap();
+    let mut engine = Engine::new(400, 180);
+    let mut layout = HorizontalLayout::new(20, 20, 360, 80,
+    PaddingConstraint::new(0, 0, 0, 0, 1));
+    let mut widget1 = BaseWidget::new(0, 0, 0, 0);
+
+    widget1
+        .get_config()
+        .set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
+    widget1
+        .get_config()
+        .set_numeric(CONFIG_BORDER_WIDTH, 2);
+
+    let mut widget2 = BaseWidget::new(0, 0, 0, 0);
+
+    widget2
+        .get_config()
+        .set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
+    widget2
+        .get_config()
+        .set_numeric(CONFIG_BORDER_WIDTH, 2);
+
+    let widget1_id = engine.add_widget(Box::new(widget1), String::from("widget1"));
+    let widget2_id = engine.add_widget(Box::new(widget2), String::from("widget2"));
+
+    layout.add_widget(widget1_id, LayoutPosition::new(0, 0));
+    layout.add_widget(widget2_id, LayoutPosition::new(1, 0));
+    engine.add_layout(Box::new(layout));
+
+    engine.run(sdl_context, window);
+}

--- a/examples/horizontal_layout.rs
+++ b/examples/horizontal_layout.rs
@@ -1,14 +1,17 @@
 extern crate pushrod;
 extern crate sdl2;
 
-use pushrod::render::engine::Engine;
-use pushrod::render::widget::{Widget, BaseWidget};
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, PaddingConstraint, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH, CONFIG_COLOR_TEXT, CONFIG_COLOR_BASE};
-use pushrod::widgets::progress_widget::*;
-use sdl2::pixels::Color;
 use pushrod::layouts::horizontal_layout::HorizontalLayout;
+use pushrod::render::engine::Engine;
 use pushrod::render::layout::{Layout, LayoutPosition};
-use pushrod::widgets::text_widget::{TextWidget, TextJustify};
+use pushrod::render::widget::{BaseWidget, Widget};
+use pushrod::render::widget_config::{
+    PaddingConstraint, CONFIG_BORDER_WIDTH, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER,
+    CONFIG_COLOR_SECONDARY, CONFIG_COLOR_TEXT,
+};
+use pushrod::widgets::progress_widget::*;
+use pushrod::widgets::text_widget::{TextJustify, TextWidget};
+use sdl2::pixels::Color;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
@@ -20,26 +23,21 @@ pub fn main() {
         .build()
         .unwrap();
     let mut engine = Engine::new(400, 240);
-    let mut layout = HorizontalLayout::new(20, 20, 360, 80,
-    PaddingConstraint::new(0, 0, 0, 0, 1));
+    let mut layout = HorizontalLayout::new(20, 20, 360, 80, PaddingConstraint::new(0, 0, 0, 0, 1));
 
     let mut widget1 = BaseWidget::new(0, 0, 0, 0);
 
     widget1
         .get_config()
         .set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
-    widget1
-        .get_config()
-        .set_numeric(CONFIG_BORDER_WIDTH, 2);
+    widget1.get_config().set_numeric(CONFIG_BORDER_WIDTH, 2);
 
     let mut widget2 = BaseWidget::new(0, 0, 0, 0);
 
     widget2
         .get_config()
         .set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
-    widget2
-        .get_config()
-        .set_numeric(CONFIG_BORDER_WIDTH, 2);
+    widget2.get_config().set_numeric(CONFIG_BORDER_WIDTH, 2);
 
     let widget1_id = engine.add_widget(Box::new(widget1), String::from("widget1"));
     let widget2_id = engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/horizontal_layout.rs
+++ b/examples/horizontal_layout.rs
@@ -3,24 +3,26 @@ extern crate sdl2;
 
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::{Widget, BaseWidget};
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, PaddingConstraint, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH};
+use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, PaddingConstraint, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH, CONFIG_COLOR_TEXT, CONFIG_COLOR_BASE};
 use pushrod::widgets::progress_widget::*;
 use sdl2::pixels::Color;
 use pushrod::layouts::horizontal_layout::HorizontalLayout;
 use pushrod::render::layout::{Layout, LayoutPosition};
+use pushrod::widgets::text_widget::{TextWidget, TextJustify};
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();
     let video_subsystem = sdl_context.video().unwrap();
     let window = video_subsystem
-        .window("pushrod-render horizontal layout demo", 400, 180)
+        .window("pushrod-render horizontal layout demo", 400, 240)
         .position_centered()
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 180);
+    let mut engine = Engine::new(400, 240);
     let mut layout = HorizontalLayout::new(20, 20, 360, 80,
     PaddingConstraint::new(0, 0, 0, 0, 1));
+
     let mut widget1 = BaseWidget::new(0, 0, 0, 0);
 
     widget1
@@ -45,6 +47,24 @@ pub fn main() {
     layout.add_widget(widget1_id, LayoutPosition::new(0, 0));
     layout.add_widget(widget2_id, LayoutPosition::new(1, 0));
     engine.add_layout(Box::new(layout));
+
+    let mut widget1 = TextWidget::new(
+        String::from("assets/OpenSans-Regular.ttf"),
+        sdl2::ttf::FontStyle::NORMAL,
+        16,
+        TextJustify::Right,
+        String::from("Spacing:"),
+        20,
+        106,
+        80,
+        22,
+    );
+
+    widget1
+        .get_config()
+        .set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
+
+    engine.add_widget(Box::new(widget1), String::from("text_widget1"));
 
     engine.run(sdl_context, window);
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -19,7 +19,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(WIDTH, HEIGHT);
     let mut widget1 =
         ImageWidget::new(String::from("assets/rust-48x48.jpg"), 20, 16, 60, 60, false);
 
@@ -133,8 +133,6 @@ pub fn main() {
 
     widget12.set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
     widget12.set_compass(CONFIG_IMAGE_POSITION, CompassPosition::NW);
-
-    engine.setup(WIDTH, HEIGHT);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 180);
     let widget1 = ImageButtonWidget::new(
         20,
         20,
@@ -44,8 +44,6 @@ pub fn main() {
         24,
         String::from("assets/checkbox_unselected.png"),
     );
-
-    engine.setup(500, 180);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 180);
     let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
@@ -28,8 +28,6 @@ pub fn main() {
     let mut widget3 = ProgressWidget::new(20, 120, 360, 40, 75);
 
     widget3.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
-
-    engine.setup(500, 180);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/push_button.rs
+++ b/examples/push_button.rs
@@ -21,7 +21,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 100);
     let mut button1 = PushButtonWidget::new(20, 20, 360, 60, String::from("Click me!"), 40);
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
@@ -29,8 +29,6 @@ pub fn main() {
     button1.on_click(|x, _widgets| {
         eprintln!("Click me clicked!");
     });
-
-    engine.setup(400, 100);
 
     engine.add_widget(Box::new(button1), String::from("button1"));
 

--- a/examples/push_button.rs
+++ b/examples/push_button.rs
@@ -26,7 +26,7 @@ pub fn main() {
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button1.on_click(|x, _widgets| {
+    button1.on_click(|x, _widgets, _layouts| {
         eprintln!("Click me clicked!");
     });
 

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -20,7 +20,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(800, 600);
     let mut new_base_widget = BaseWidget::new(100, 100, 600, 400);
 
     new_base_widget
@@ -78,8 +78,6 @@ pub fn main() {
                 button, clicks, state
             );
         });
-
-    engine.setup(800, 600);
 
     engine.add_widget(Box::new(new_base_widget), String::from("widget1"));
 

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -70,14 +70,14 @@ pub fn main() {
             eprintln!("Mouse Scrolled: {:?}", points);
         });
 
-    new_base_widget
-        .get_callbacks()
-        .on_mouse_clicked(|_widget, _widgets, _layouts, button, clicks, state| {
+    new_base_widget.get_callbacks().on_mouse_clicked(
+        |_widget, _widgets, _layouts, button, clicks, state| {
             eprintln!(
                 "Mouse Clicked: button={} clicks={} state={}",
                 button, clicks, state
             );
-        });
+        },
+    );
 
     engine.add_widget(Box::new(new_base_widget), String::from("widget1"));
 

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -32,7 +32,7 @@ pub fn main() {
 
     new_base_widget
         .get_callbacks()
-        .on_mouse_entered(|x, _widgets| {
+        .on_mouse_entered(|x, _widgets, _layouts| {
             x.get_config()
                 .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 0, 0));
             x.get_config().set_invalidate(true);
@@ -46,7 +46,7 @@ pub fn main() {
 
     new_base_widget
         .get_callbacks()
-        .on_mouse_exited(|x, _widgets| {
+        .on_mouse_exited(|x, _widgets, _layouts| {
             x.get_config()
                 .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
             x.get_config().set_invalidate(true);
@@ -60,19 +60,19 @@ pub fn main() {
 
     new_base_widget
         .get_callbacks()
-        .on_mouse_moved(|_widget, _widgets, points| {
+        .on_mouse_moved(|_widget, _widgets, _layouts, points| {
             eprintln!("Mouse Moved: {:?}", points);
         });
 
     new_base_widget
         .get_callbacks()
-        .on_mouse_scrolled(|_widget, _widgets, points| {
+        .on_mouse_scrolled(|_widget, _widgets, _layouts, points| {
             eprintln!("Mouse Scrolled: {:?}", points);
         });
 
     new_base_widget
         .get_callbacks()
-        .on_mouse_clicked(|_widget, _widgets, button, clicks, state| {
+        .on_mouse_clicked(|_widget, _widgets, _layouts, button, clicks, state| {
             eprintln!(
                 "Mouse Clicked: button={} clicks={} state={}",
                 button, clicks, state

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(500, 200);
     let mut widget1 = TextWidget::new(
         String::from("assets/OpenSans-Regular.ttf"),
         sdl2::ttf::FontStyle::NORMAL,
@@ -64,8 +64,6 @@ pub fn main() {
     widget3
         .get_config()
         .set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 255));
-
-    engine.setup(500, 200);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -48,7 +48,7 @@ pub fn main() {
     widget3.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
 
     let mut timer = TimerWidget::new(100, true);
-    timer.on_timeout(|x, _widgets| {
+    timer.on_timeout(|x, _widgets, _layouts| {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -34,7 +34,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 180);
     let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
@@ -63,8 +63,6 @@ pub fn main() {
         cast!(_widgets, widget2_id, ProgressWidget).set_progress(progress2_value);
         cast!(_widgets, widget3_id, ProgressWidget).set_progress(progress3_value);
     });
-
-    engine.setup(500, 180);
 
     engine.add_widget(Box::new(widget1), String::from("widget1"));
     engine.add_widget(Box::new(widget2), String::from("widget2"));

--- a/examples/toggle_button.rs
+++ b/examples/toggle_button.rs
@@ -26,7 +26,7 @@ pub fn main() {
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button1.on_toggle(|x, _widgets, _state| {
+    button1.on_toggle(|x, _widgets, _layouts, _state| {
         eprintln!("1 Toggled: {}", _state);
     });
 
@@ -34,7 +34,7 @@ pub fn main() {
 
     button2.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button2.on_toggle(|x, _widgets, _state| {
+    button2.on_toggle(|x, _widgets, _layouts, _state| {
         eprintln!("2 Toggled: {}", _state);
     });
 

--- a/examples/toggle_button.rs
+++ b/examples/toggle_button.rs
@@ -21,7 +21,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new();
+    let mut engine = Engine::new(400, 100);
     let mut button1 = ToggleButtonWidget::new(20, 20, 170, 60, String::from("1"), 40, false);
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
@@ -37,8 +37,6 @@ pub fn main() {
     button2.on_toggle(|x, _widgets, _state| {
         eprintln!("2 Toggled: {}", _state);
     });
-
-    engine.setup(400, 100);
 
     engine.add_widget(Box::new(button1), String::from("button1"));
     engine.add_widget(Box::new(button2), String::from("button2"));

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -73,7 +73,7 @@ impl Layout for HorizontalLayout {
         let offset_y: i32 = self.origin[1];
         let num_widgets = self.widget_ids.len() as u32;
         let widget_width = self.size[SIZE_WIDTH] / num_widgets as u32;
-        let subtractor_right = (self.padding.spacing / 2) as u32;
+        let subtractor_right = ((self.padding.spacing / 2) + 1) as u32;
         let subtractor_left = (subtractor_right - 1) as u32;
 
         eprintln!(
@@ -115,6 +115,8 @@ impl Layout for HorizontalLayout {
                 .get_config()
                 .set_invalidate(true);
         }
+
+        self.invalidated = false;
     }
 
     fn needs_layout(&self) -> bool {

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -15,7 +15,7 @@
 
 use crate::render::layout::{Layout, LayoutPosition};
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::widget_config::{PaddingConstraint, CONFIG_SIZE, CONFIG_ORIGIN};
+use crate::render::widget_config::{PaddingConstraint, CONFIG_ORIGIN, CONFIG_SIZE};
 use crate::render::{Points, Size, SIZE_HEIGHT, SIZE_WIDTH};
 
 /// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -42,7 +42,9 @@ impl HorizontalLayout {
     }
 }
 
-/// This is the `Layout` implementation for the `HorizontalLayout` manager.
+/// This is the `Layout` implementation for the `HorizontalLayout` manager.  This `Layout` manager will
+/// not reposition any objects within the bounds of the `Layout` until at least 2 objects have been
+/// added to the bounds of the `Layout`.
 impl Layout for HorizontalLayout {
     /// Adds a widget to the `HorizontalLayout` managed stack.
     fn add_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
@@ -60,7 +62,8 @@ impl Layout for HorizontalLayout {
         self.padding.clone()
     }
 
-    /// Adjusts the layout of the `Widget`s managed by this `Layout` manager.
+    /// Adjusts the layout of the `Widget`s managed by this `Layout` manager.  Currently only obeys
+    /// the spacing in the object.  The rest of the padding is not (yet) honored.
     fn do_layout(&mut self, _widgets: &[WidgetContainer]) {
         if self.widget_ids.len() <= 1 {
             return;

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -15,7 +15,7 @@
 
 use crate::render::layout::{Layout, LayoutPosition};
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::widget_config::{PaddingConstraint, CONFIG_SIZE};
+use crate::render::widget_config::{PaddingConstraint, CONFIG_SIZE, CONFIG_ORIGIN};
 use crate::render::{Points, Size, SIZE_HEIGHT, SIZE_WIDTH};
 
 /// This is the `HorizontalLayout` storage structure for the `HorizontalLayout` implementation.
@@ -66,6 +66,8 @@ impl Layout for HorizontalLayout {
             return;
         }
 
+        let offset_x: i32 = self.origin[0];
+        let offset_y: i32 = self.origin[1];
         let num_widgets = self.widget_ids.len() as u32;
         let widget_width = self.size[SIZE_WIDTH] / num_widgets as u32;
         let subtractor_right = (self.padding.spacing / 2) as u32;
@@ -96,13 +98,19 @@ impl Layout for HorizontalLayout {
                 .widget
                 .borrow_mut()
                 .get_config()
-                .to_x(set_x);
+                .set_point(CONFIG_ORIGIN, offset_x + set_x, offset_y);
 
             _widgets[widget_id as usize]
                 .widget
                 .borrow_mut()
                 .get_config()
                 .set_size(CONFIG_SIZE, set_width, self.size[SIZE_HEIGHT]);
+
+            _widgets[widget_id as usize]
+                .widget
+                .borrow_mut()
+                .get_config()
+                .set_invalidate(true);
         }
     }
 

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -73,8 +73,8 @@ impl Layout for HorizontalLayout {
         let offset_y: i32 = self.origin[1];
         let num_widgets = self.widget_ids.len() as u32;
         let widget_width = self.size[SIZE_WIDTH] / num_widgets as u32;
-        let subtractor_right = ((self.padding.spacing / 2) + 1) as u32;
-        let subtractor_left = (subtractor_right - 1) as u32;
+        let subtractor_right = ((self.padding.spacing as f64 / 2.0).ceil()) as u32;
+        let subtractor_left = ((self.padding.spacing as f64 / 2.0).floor()) as u32;
 
         eprintln!(
             "HorizontalLayout: rightside={} leftside={}",
@@ -90,10 +90,10 @@ impl Layout for HorizontalLayout {
                 set_x = (i * set_width) as i32;
                 set_width = widget_width - subtractor_right;
             } else if i == num_widgets - 1 {
-                set_x = (i * set_width) as i32 - subtractor_left as i32;
+                set_x = (i * set_width) as i32 + subtractor_left as i32;
                 set_width = widget_width - subtractor_left;
             } else {
-                set_x = (i * set_width) as i32 - subtractor_left as i32;
+                set_x = (i * set_width) as i32 + subtractor_left as i32;
                 set_width = widget_width - subtractor_left - subtractor_right;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,10 @@ mod macros {
         () => {
             /// This function is a macro-created tick callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn tick_callback(&mut self, _widgets: &[WidgetContainer]) {
+            fn tick_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
                 if self.get_callbacks().has_on_tick() {
                     if let Some(mut cb) = self.get_callbacks().on_tick.take() {
-                        cb(self, _widgets);
+                        cb(self, _widgets, _layouts);
                         self.get_callbacks().on_tick = Some(cb);
                     }
                 }
@@ -87,10 +87,10 @@ mod macros {
 
             /// This function is a macro-created mouse entered callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn mouse_entered_callback(&mut self, _widgets: &[WidgetContainer]) {
+            fn mouse_entered_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
                 if self.get_callbacks().has_on_mouse_entered() {
                     if let Some(mut cb) = self.get_callbacks().on_mouse_entered.take() {
-                        cb(self, _widgets);
+                        cb(self, _widgets, _layouts);
                         self.get_callbacks().on_mouse_entered = Some(cb);
                     }
                 }
@@ -98,10 +98,10 @@ mod macros {
 
             /// This function is a macro-created mouse exited callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn mouse_exited_callback(&mut self, _widgets: &[WidgetContainer]) {
+            fn mouse_exited_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
                 if self.get_callbacks().has_on_mouse_exited() {
                     if let Some(mut cb) = self.get_callbacks().on_mouse_exited.take() {
-                        cb(self, _widgets);
+                        cb(self, _widgets, _layouts);
                         self.get_callbacks().on_mouse_exited = Some(cb);
                     }
                 }
@@ -109,10 +109,10 @@ mod macros {
 
             /// This function is a macro-created mouse moved callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn mouse_moved_callback(&mut self, _widgets: &[WidgetContainer], _points: Points) {
+            fn mouse_moved_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
                 if self.get_callbacks().has_on_mouse_moved() {
                     if let Some(mut cb) = self.get_callbacks().on_mouse_moved.take() {
-                        cb(self, _widgets, _points);
+                        cb(self, _widgets, _layouts, _points);
                         self.get_callbacks().on_mouse_moved = Some(cb);
                     }
                 }
@@ -120,10 +120,10 @@ mod macros {
 
             /// This function is a macro-created mouse scrolled callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn mouse_scrolled_callback(&mut self, _widgets: &[WidgetContainer], _points: Points) {
+            fn mouse_scrolled_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
                 if self.get_callbacks().has_on_mouse_scrolled() {
                     if let Some(mut cb) = self.get_callbacks().on_mouse_scrolled.take() {
-                        cb(self, _widgets, _points);
+                        cb(self, _widgets, _layouts, _points);
                         self.get_callbacks().on_mouse_scrolled = Some(cb);
                     }
                 }
@@ -131,10 +131,10 @@ mod macros {
 
             /// This function is a macro-created mouse scrolled callback override, created by the
             /// `default_widget_callbacks!()` macro.
-            fn button_clicked_callback(&mut self, _widgets: &[WidgetContainer], _button: u8, _clicks: u8, _state: bool) {
+            fn button_clicked_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _button: u8, _clicks: u8, _state: bool) {
                 if self.get_callbacks().has_on_mouse_clicked() {
                     if let Some(mut cb) = self.get_callbacks().on_mouse_clicked.take() {
-                        cb(self, _widgets, _button, _clicks, _state);
+                        cb(self, _widgets, _layouts, _button, _clicks, _state);
                         self.get_callbacks().on_mouse_clicked = Some(cb);
                     }
                 }

--- a/src/render/callbacks.rs
+++ b/src/render/callbacks.rs
@@ -15,21 +15,22 @@
 
 use crate::render::widget::Widget;
 use crate::render::widget_cache::WidgetContainer;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is an `FnMut` type that takes no additional parameters, returning a mutable reference
-/// to the current `Widget`, and borrowing the `WidgetContainer` list.
-pub type FunctionNoParametersType = Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer])>>;
+/// to the current `Widget`, and borrowing the `WidgetContainer` and `LayoutContainer` lists.
+pub type FunctionNoParametersType = Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is an `FnMut` that takes a `Point` as a `Vec<i32>` of points: X and Y, returning a mutable reference
-/// to the current `Widget`, and borrowing the `WidgetContainer` list.
+/// to the current `Widget`, and borrowing the `WidgetContainer` and `LayoutContainer` lists.
 pub type FunctionPointParametersType =
-    Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], Vec<i32>)>>;
+    Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer], Vec<i32>)>>;
 
 /// This is an `FnMut` that takes a button click ID, the number of clicks, the click state (`true` indicating
 /// the click was pressed, `false` otherwise), returning a mutable reference
-/// to the current `Widget`, and borrowing the `WidgetContainer` list.
+/// to the current `Widget`, and borrowing the `WidgetContainer` and `LayoutContainer` lists.
 pub type FunctionClickParametersType =
-    Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], u8, u8, bool)>>;
+    Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer], u8, u8, bool)>>;
 
 /// This is a registry that contains a series of `FnMut` definitions for actions that can be applied
 /// to a `Widget`.  These can vary from a screen refresh (`tick`), to a mouse move event, etc.  Each
@@ -102,7 +103,7 @@ impl CallbackRegistry {
     /// is not set, this function will be bypassed.
     pub fn on_tick<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer]) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer]) + 'static,
     {
         self.on_tick = Some(Box::new(callback));
         self.has_on_tick = true;
@@ -112,7 +113,7 @@ impl CallbackRegistry {
     /// is not set, this function will be bypassed.
     pub fn on_mouse_entered<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer]) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer]) + 'static,
     {
         self.on_mouse_entered = Some(Box::new(callback));
         self.has_on_mouse_entered = true;
@@ -122,7 +123,7 @@ impl CallbackRegistry {
     /// is not set, this function will be bypassed.
     pub fn on_mouse_exited<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer]) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer]) + 'static,
     {
         self.on_mouse_exited = Some(Box::new(callback));
         self.has_on_mouse_exited = true;
@@ -132,7 +133,7 @@ impl CallbackRegistry {
     /// is not set, this function will be bypassed.
     pub fn on_mouse_moved<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer], Vec<i32>) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer], Vec<i32>) + 'static,
     {
         self.on_mouse_moved = Some(Box::new(callback));
         self.has_on_mouse_moved = true;
@@ -142,7 +143,7 @@ impl CallbackRegistry {
     /// `Widget`.  If this is not set, this function will be bypassed.
     pub fn on_mouse_scrolled<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer], Vec<i32>) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer], Vec<i32>) + 'static,
     {
         self.on_mouse_scrolled = Some(Box::new(callback));
         self.has_on_mouse_scrolled = true;
@@ -152,7 +153,7 @@ impl CallbackRegistry {
     /// `Widget`.  If this is not set, this function will be bypassed.
     pub fn on_mouse_clicked<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut dyn Widget, &[WidgetContainer], u8, u8, bool) + 'static,
+        F: FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer], u8, u8, bool) + 'static,
     {
         self.on_mouse_clicked = Some(Box::new(callback));
         self.has_on_mouse_clicked = true;

--- a/src/render/callbacks.rs
+++ b/src/render/callbacks.rs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget::Widget;
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is an `FnMut` type that takes no additional parameters, returning a mutable reference
 /// to the current `Widget`, and borrowing the `WidgetContainer` and `LayoutContainer` lists.
-pub type FunctionNoParametersType = Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer])>>;
+pub type FunctionNoParametersType =
+    Option<Box<dyn FnMut(&mut dyn Widget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is an `FnMut` that takes a `Point` as a `Vec<i32>` of points: X and Y, returning a mutable reference
 /// to the current `Widget`, and borrowing the `WidgetContainer` and `LayoutContainer` lists.

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -59,13 +59,13 @@ impl Engine {
     /// required as part of the draw cycle.
     pub fn new(w: u32, h: u32) -> Self {
         let base_widget = BaseWidget::new(0, 0, w, h);
-        let mut cache = WidgetCache::new();
+        let mut cache = WidgetCache::default();
 
         cache.add_widget(Box::new(base_widget), "base".to_string());
 
         Self {
             widget_cache: cache,
-            layout_cache: LayoutCache::new(),
+            layout_cache: LayoutCache::default(),
             current_widget_id: 0,
         }
     }
@@ -108,10 +108,13 @@ impl Engine {
                     Event::MouseButtonUp {
                         mouse_btn, clicks, ..
                     } => {
-                        self.widget_cache
-                            .button_clicked(-1, mouse_btn as u8, clicks, false,
-                                            self.layout_cache.get_layout_cache(),
-                            );
+                        self.widget_cache.button_clicked(
+                            -1,
+                            mouse_btn as u8,
+                            clicks,
+                            false,
+                            self.layout_cache.get_layout_cache(),
+                        );
                     }
 
                     Event::MouseMotion { x, y, .. } => {
@@ -120,25 +123,27 @@ impl Engine {
                         self.current_widget_id = self.widget_cache.find_widget(x, y);
 
                         if cur_widget_id != self.current_widget_id {
-                            self.widget_cache.mouse_exited(cur_widget_id,
-                                                           self.layout_cache.get_layout_cache(),
-                            );
-                            self.widget_cache.mouse_entered(self.current_widget_id,
-                                                            self.layout_cache.get_layout_cache(),
+                            self.widget_cache
+                                .mouse_exited(cur_widget_id, self.layout_cache.get_layout_cache());
+                            self.widget_cache.mouse_entered(
+                                self.current_widget_id,
+                                self.layout_cache.get_layout_cache(),
                             );
                         }
 
-                        self.widget_cache
-                            .mouse_moved(self.current_widget_id, vec![x, y],
-                                         self.layout_cache.get_layout_cache(),
-                            );
+                        self.widget_cache.mouse_moved(
+                            self.current_widget_id,
+                            vec![x, y],
+                            self.layout_cache.get_layout_cache(),
+                        );
                     }
 
                     Event::MouseWheel { x, y, .. } => {
-                        self.widget_cache
-                            .mouse_scrolled(self.current_widget_id, vec![x, y],
-                                            self.layout_cache.get_layout_cache(),
-                            );
+                        self.widget_cache.mouse_scrolled(
+                            self.current_widget_id,
+                            vec![x, y],
+                            self.layout_cache.get_layout_cache(),
+                        );
                     }
 
                     Event::Quit { .. } => {
@@ -146,10 +151,11 @@ impl Engine {
                     }
 
                     remaining_event => {
-                        self.widget_cache
-                            .other_event(self.current_widget_id, remaining_event,
-                                         self.layout_cache.get_layout_cache(),
-                            );
+                        self.widget_cache.other_event(
+                            self.current_widget_id,
+                            remaining_event,
+                            self.layout_cache.get_layout_cache(),
+                        );
                     }
                 }
             }

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -51,20 +51,20 @@ pub struct Engine {
 /// That's all there is to it.  If you want to see more interactions on how the `Engine` is used in
 /// an application, check out the demo test code, and look at `rust-pushrod-chassis`.
 impl Engine {
-    /// Creates a new `Engine` object.
-    pub fn new() -> Self {
+    /// Creates a new `Engine` object.  Sets the engine up with the bounds of the screen, which
+    /// must be provided at instantiation time.  This is in order to set up the `BaseWidget` in the
+    /// top-level of the `Engine`, so that it knows what area of the screen to refresh when
+    /// required as part of the draw cycle.
+    pub fn new(w: u32, h: u32) -> Self {
+        let base_widget = BaseWidget::new(0, 0, w, h);
+        let mut cache = WidgetCache::new();
+
+        cache.add_widget(Box::new(base_widget), "base".to_string());
+
         Self {
-            cache: WidgetCache::new(),
+            cache,
             current_widget_id: 0,
         }
-    }
-
-    /// Sets up the top-level widget so that other widgets can be added to the screen.
-    pub fn setup(&mut self, window_width: u32, window_height: u32) {
-        let base_widget = BaseWidget::new(0, 0, window_width, window_height);
-
-        self.cache
-            .add_widget(Box::new(base_widget), "base".to_string());
     }
 
     /// Adds a widget to the display list.  Widgets are rendered in the order in which they were
@@ -164,11 +164,5 @@ impl Engine {
 
             ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
         }
-    }
-}
-
-impl Default for Engine {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -101,6 +101,7 @@ impl Engine {
                             mouse_btn as u8,
                             clicks,
                             true,
+                            self.layout_cache.get_layout_cache(),
                         );
                     }
 
@@ -108,7 +109,9 @@ impl Engine {
                         mouse_btn, clicks, ..
                     } => {
                         self.widget_cache
-                            .button_clicked(-1, mouse_btn as u8, clicks, false);
+                            .button_clicked(-1, mouse_btn as u8, clicks, false,
+                                            self.layout_cache.get_layout_cache(),
+                            );
                     }
 
                     Event::MouseMotion { x, y, .. } => {
@@ -117,17 +120,25 @@ impl Engine {
                         self.current_widget_id = self.widget_cache.find_widget(x, y);
 
                         if cur_widget_id != self.current_widget_id {
-                            self.widget_cache.mouse_exited(cur_widget_id);
-                            self.widget_cache.mouse_entered(self.current_widget_id);
+                            self.widget_cache.mouse_exited(cur_widget_id,
+                                                           self.layout_cache.get_layout_cache(),
+                            );
+                            self.widget_cache.mouse_entered(self.current_widget_id,
+                                                            self.layout_cache.get_layout_cache(),
+                            );
                         }
 
                         self.widget_cache
-                            .mouse_moved(self.current_widget_id, vec![x, y]);
+                            .mouse_moved(self.current_widget_id, vec![x, y],
+                                         self.layout_cache.get_layout_cache(),
+                            );
                     }
 
                     Event::MouseWheel { x, y, .. } => {
                         self.widget_cache
-                            .mouse_scrolled(self.current_widget_id, vec![x, y]);
+                            .mouse_scrolled(self.current_widget_id, vec![x, y],
+                                            self.layout_cache.get_layout_cache(),
+                            );
                     }
 
                     Event::Quit { .. } => {
@@ -136,12 +147,14 @@ impl Engine {
 
                     remaining_event => {
                         self.widget_cache
-                            .other_event(self.current_widget_id, remaining_event);
+                            .other_event(self.current_widget_id, remaining_event,
+                                         self.layout_cache.get_layout_cache(),
+                            );
                     }
                 }
             }
 
-            self.widget_cache.tick();
+            self.widget_cache.tick(self.layout_cache.get_layout_cache());
             self.layout_cache
                 .do_layout(self.widget_cache.borrow_cache());
             self.widget_cache.draw_loop(&mut canvas);

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -14,14 +14,14 @@
 // limitations under the License.
 
 use sdl2::event::Event;
-//use sdl2::messagebox::*;
 use sdl2::video::Window;
 use sdl2::Sdl;
 
+use crate::render::layout::Layout;
+use crate::render::layout_cache::LayoutCache;
 use crate::render::widget::{BaseWidget, Widget};
 use crate::render::widget_cache::WidgetCache;
 use std::time::Duration;
-use crate::render::layout_cache::LayoutCache;
 
 /// This is a storage container for the Pushrod event engine.
 pub struct Engine {
@@ -70,10 +70,15 @@ impl Engine {
         }
     }
 
-    /// Adds a widget to the display list.  Widgets are rendered in the order in which they were
+    /// Adds a `Widget` to the display list.  `Widget`s are rendered in the order in which they were
     /// created in the display list.
     pub fn add_widget(&mut self, widget: Box<dyn Widget>, widget_name: String) -> i32 {
         self.widget_cache.add_widget(widget, widget_name)
+    }
+
+    /// Adds a `Layout` to the `Layout` list.
+    pub fn add_layout(&mut self, layout: Box<dyn Layout>) -> i32 {
+        self.layout_cache.add_layout(layout)
     }
 
     /// Main application run loop, controls interaction between the user and the application.
@@ -116,7 +121,8 @@ impl Engine {
                             self.widget_cache.mouse_entered(self.current_widget_id);
                         }
 
-                        self.widget_cache.mouse_moved(self.current_widget_id, vec![x, y]);
+                        self.widget_cache
+                            .mouse_moved(self.current_widget_id, vec![x, y]);
                     }
 
                     Event::MouseWheel { x, y, .. } => {
@@ -136,6 +142,8 @@ impl Engine {
             }
 
             self.widget_cache.tick();
+            self.layout_cache
+                .do_layout(self.widget_cache.borrow_cache());
             self.widget_cache.draw_loop(&mut canvas);
 
             ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -27,10 +27,7 @@ pub struct LayoutPosition {
 /// Implementation of the `LayoutPosition` that generates a new `LayoutPosition` object.
 impl LayoutPosition {
     pub fn new(x: i32, y: i32) -> Self {
-        Self {
-            x,
-            y,
-        }
+        Self { x, y }
     }
 }
 

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -24,6 +24,16 @@ pub struct LayoutPosition {
     pub y: i32,
 }
 
+/// Implementation of the `LayoutPosition` that generates a new `LayoutPosition` object.
+impl LayoutPosition {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self {
+            x,
+            y,
+        }
+    }
+}
+
 /// This is a `Layout` trait that is used by the `Engine` service, which stores a list of `Widget`s,
 /// their positions (based on matrix coordinates), and an entry point to trigger the layout compute
 /// action.

--- a/src/render/layout_cache.rs
+++ b/src/render/layout_cache.rs
@@ -25,26 +25,28 @@ pub struct LayoutContainer {
 
 /// This is an implementation that allows for creation of a `LayoutContainer`.
 impl LayoutContainer {
+    /// Creates a new `LayoutContainer`-wrapped `Layout` object.
     pub fn new(layout: Box<dyn Layout>, layout_id: i32) -> Self {
         Self {
             layout: RefCell::new(layout),
             layout_id,
         }
     }
+
+    /// Retrieves the current layout ID.
+    pub fn get_layout_id(&self) -> i32 {
+        self.layout_id
+    }
 }
 
 /// This is a container object that stores a `Vec` of `LayoutContainer` objects for its cache.
+#[derive(Default)]
 pub struct LayoutCache {
     cache: Vec<LayoutContainer>,
 }
 
 /// This is the implementation of the `LayoutCache`.
 impl LayoutCache {
-    /// Creates a new cache object.
-    pub fn new() -> Self {
-        Self { cache: Vec::new() }
-    }
-
     /// Adds a `Box<Layout>` to the `Layout` stack.
     pub fn add_layout(&mut self, layout: Box<dyn Layout>) -> i32 {
         let layout_id = self.cache.len() as i32;

--- a/src/render/layout_cache.rs
+++ b/src/render/layout_cache.rs
@@ -1,0 +1,56 @@
+// Pushrod Rendering Library
+// Layout Caching Library
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cell::RefCell;
+use crate::render::layout::Layout;
+
+pub struct LayoutContainer {
+    pub layout: RefCell<Box<dyn Layout>>,
+    layout_id: i32,
+}
+
+impl LayoutContainer {
+    pub fn new(layout: Box<dyn Layout>, layout_id: i32) -> Self {
+        Self {
+            layout: RefCell::new(layout),
+            layout_id,
+        }
+    }
+}
+
+pub struct LayoutCache {
+    cache: Vec<LayoutContainer>,
+}
+
+impl LayoutCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Vec::new(),
+        }
+    }
+
+    pub fn add_layout(&mut self, layout: Box<dyn Layout>) -> i32 {
+        let layout_id = self.cache.len() as i32;
+
+        self.cache.push(LayoutContainer::new(layout, layout_id));
+
+        layout_id
+    }
+
+    pub fn get_layout_by_id(&mut self, id: i32) -> &mut LayoutContainer {
+        &mut self.cache[id as usize]
+    }
+
+}

--- a/src/render/layout_cache.rs
+++ b/src/render/layout_cache.rs
@@ -17,11 +17,13 @@ use crate::render::layout::Layout;
 use crate::render::widget_cache::WidgetContainer;
 use std::cell::RefCell;
 
+/// This is a container object that stores a `Layout` object, and its ID.
 pub struct LayoutContainer {
     pub layout: RefCell<Box<dyn Layout>>,
     layout_id: i32,
 }
 
+/// This is an implementation that allows for creation of a `LayoutContainer`.
 impl LayoutContainer {
     pub fn new(layout: Box<dyn Layout>, layout_id: i32) -> Self {
         Self {
@@ -31,15 +33,19 @@ impl LayoutContainer {
     }
 }
 
+/// This is a container object that stores a `Vec` of `LayoutContainer` objects for its cache.
 pub struct LayoutCache {
     cache: Vec<LayoutContainer>,
 }
 
+/// This is the implementation of the `LayoutCache`.
 impl LayoutCache {
+    /// Creates a new cache object.
     pub fn new() -> Self {
         Self { cache: Vec::new() }
     }
 
+    /// Adds a `Box<Layout>` to the `Layout` stack.
     pub fn add_layout(&mut self, layout: Box<dyn Layout>) -> i32 {
         let layout_id = self.cache.len() as i32;
 
@@ -48,14 +54,18 @@ impl LayoutCache {
         layout_id
     }
 
+    /// Retrieves a `&mut LayoutContainer` object by its ID.
     pub fn get_layout_by_id(&mut self, id: i32) -> &mut LayoutContainer {
         &mut self.cache[id as usize]
     }
 
+    /// Retrieves a borrowed slice of the `LayoutContainer` cache that can be sent to callbacks.
     pub fn get_layout_cache(&self) -> &[LayoutContainer] {
         &self.cache
     }
 
+    /// Performs the `do_layout` call on `Layout` objects only if their `needs_layout` flag is set
+    /// to `true`.
     pub fn do_layout(&self, widgets: &[WidgetContainer]) {
         for x in &self.cache {
             let needs_layout = x.layout.borrow().needs_layout();

--- a/src/render/layout_cache.rs
+++ b/src/render/layout_cache.rs
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use crate::render::layout::Layout;
+use crate::render::widget_cache::WidgetContainer;
+use std::cell::RefCell;
 
 pub struct LayoutContainer {
     pub layout: RefCell<Box<dyn Layout>>,
@@ -36,9 +37,7 @@ pub struct LayoutCache {
 
 impl LayoutCache {
     pub fn new() -> Self {
-        Self {
-            cache: Vec::new(),
-        }
+        Self { cache: Vec::new() }
     }
 
     pub fn add_layout(&mut self, layout: Box<dyn Layout>) -> i32 {
@@ -53,4 +52,13 @@ impl LayoutCache {
         &mut self.cache[id as usize]
     }
 
+    pub fn do_layout(&self, widgets: &[WidgetContainer]) {
+        for x in &self.cache {
+            let needs_layout = x.layout.borrow().needs_layout();
+
+            if needs_layout {
+                x.layout.borrow_mut().do_layout(widgets);
+            }
+        }
+    }
 }

--- a/src/render/layout_cache.rs
+++ b/src/render/layout_cache.rs
@@ -52,6 +52,10 @@ impl LayoutCache {
         &mut self.cache[id as usize]
     }
 
+    pub fn get_layout_cache(&self) -> &[LayoutContainer] {
+        &self.cache
+    }
+
     pub fn do_layout(&self, widgets: &[WidgetContainer]) {
         for x in &self.cache {
             let needs_layout = x.layout.borrow().needs_layout();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -52,3 +52,7 @@ pub mod widget_cache;
 /// This is a layout manager description module, describing rules for `Layout` managers to be used
 /// in the system, and having `Widget`s added to them.
 pub mod layout;
+
+/// This is a caching object that stores a container of `Layout` objects, managed by the Pushrod
+/// engine.
+pub mod layout_cache;

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -18,6 +18,7 @@ use sdl2::render::Canvas;
 use sdl2::video::Window;
 
 use crate::render::callbacks::*;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::*;
 use crate::render::{Points, Size};
@@ -25,7 +26,6 @@ use sdl2::event::Event;
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This trait is shared by all `Widget` objects that have a presence on the screen.  Functions that
 /// must be implemented are documented in the trait.
@@ -71,7 +71,12 @@ pub trait Widget {
     /// When a mouse moves within the bounds of the `Widget`, this function is triggered.  It
     /// contains the `X` and `Y` coordinates relative to the bounds of the `Widget`.  The
     /// points start at `0x0`.  This function implementation is **optional**.
-    fn mouse_moved(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
+    fn mouse_moved(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _points: Points,
+    ) {
         self.mouse_moved_callback(_widgets, _layouts, _points);
     }
 
@@ -80,7 +85,12 @@ pub trait Widget {
     /// indicates vertical movement.  Positive movement means to the right or down, respectively.
     /// Negative movement means to the left or up, respectively.  This function implementation
     /// is **optional**.
-    fn mouse_scrolled(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
+    fn mouse_scrolled(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _points: Points,
+    ) {
         self.mouse_scrolled_callback(_widgets, _layouts, _points);
     }
 
@@ -112,7 +122,12 @@ pub trait Widget {
     /// When an `Event` is sent to the application that is not handled by the `Engine::run` loop, this
     /// method is called, sending the unhandled `Event` to the currently active `Widget`.  **This behavior
     /// is subject to change** as the `Engine::run` loop is modified to handle more `Event`s.
-    fn other_event(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _event: Event) {
+    fn other_event(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _event: Event,
+    ) {
         eprintln!("Other event: {:?}", _event);
     }
 
@@ -124,22 +139,44 @@ pub trait Widget {
     /// This calls the `on_mouse_entered` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_entered` callback.
-    fn mouse_entered_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {}
+    fn mouse_entered_callback(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+    ) {
+    }
 
     /// This calls the `on_mouse_exited` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_exited` callback.
-    fn mouse_exited_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {}
+    fn mouse_exited_callback(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+    ) {
+    }
 
     /// This calls the `on_mouse_moved` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_moved` callback.
-    fn mouse_moved_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {}
+    fn mouse_moved_callback(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _points: Points,
+    ) {
+    }
 
     /// This calls the `on_mouse_scrolled` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_scrolled` callback.
-    fn mouse_scrolled_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {}
+    fn mouse_scrolled_callback(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _points: Points,
+    ) {
+    }
 
     /// This calls the `on_button_clicked` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish

--- a/src/render/widget.rs
+++ b/src/render/widget.rs
@@ -25,6 +25,7 @@ use sdl2::event::Event;
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This trait is shared by all `Widget` objects that have a presence on the screen.  Functions that
 /// must be implemented are documented in the trait.
@@ -57,21 +58,21 @@ pub trait Widget {
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_entered(&mut self, _widgets: &[WidgetContainer]) {
-        self.mouse_entered_callback(_widgets);
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+        self.mouse_entered_callback(_widgets, _layouts);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_exited(&mut self, _widgets: &[WidgetContainer]) {
-        self.mouse_exited_callback(_widgets);
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+        self.mouse_exited_callback(_widgets, _layouts);
     }
 
     /// When a mouse moves within the bounds of the `Widget`, this function is triggered.  It
     /// contains the `X` and `Y` coordinates relative to the bounds of the `Widget`.  The
     /// points start at `0x0`.  This function implementation is **optional**.
-    fn mouse_moved(&mut self, _widgets: &[WidgetContainer], _points: Points) {
-        self.mouse_moved_callback(_widgets, _points);
+    fn mouse_moved(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
+        self.mouse_moved_callback(_widgets, _layouts, _points);
     }
 
     /// When a mouse scroll is triggered within the bounds of the `Widget`, this function is
@@ -79,8 +80,8 @@ pub trait Widget {
     /// indicates vertical movement.  Positive movement means to the right or down, respectively.
     /// Negative movement means to the left or up, respectively.  This function implementation
     /// is **optional**.
-    fn mouse_scrolled(&mut self, _widgets: &[WidgetContainer], _points: Points) {
-        self.mouse_scrolled_callback(_widgets, _points);
+    fn mouse_scrolled(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {
+        self.mouse_scrolled_callback(_widgets, _layouts, _points);
     }
 
     /// When a mouse button is clicked within (or outside of) the bounds of the `Widget`, this
@@ -94,50 +95,51 @@ pub trait Widget {
     fn button_clicked(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,
     ) {
-        self.button_clicked_callback(_widgets, _button, _clicks, _state);
+        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     /// When a timer tick goes by (ie. a frame is displayed on the screen), this function is
     /// called.  This function implementation is **optional**.
-    fn tick(&mut self, _widgets: &[WidgetContainer]) {
-        self.tick_callback(_widgets);
+    fn tick(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+        self.tick_callback(_widgets, _layouts);
     }
 
     /// When an `Event` is sent to the application that is not handled by the `Engine::run` loop, this
     /// method is called, sending the unhandled `Event` to the currently active `Widget`.  **This behavior
     /// is subject to change** as the `Engine::run` loop is modified to handle more `Event`s.
-    fn other_event(&mut self, _widgets: &[WidgetContainer], _event: Event) {
+    fn other_event(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _event: Event) {
         eprintln!("Other event: {:?}", _event);
     }
 
     /// This calls the `on_tick` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_tick` callback.
-    fn tick_callback(&mut self, _widgets: &[WidgetContainer]) {}
+    fn tick_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {}
 
     /// This calls the `on_mouse_entered` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_entered` callback.
-    fn mouse_entered_callback(&mut self, _widgets: &[WidgetContainer]) {}
+    fn mouse_entered_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {}
 
     /// This calls the `on_mouse_exited` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_exited` callback.
-    fn mouse_exited_callback(&mut self, _widgets: &[WidgetContainer]) {}
+    fn mouse_exited_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {}
 
     /// This calls the `on_mouse_moved` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_moved` callback.
-    fn mouse_moved_callback(&mut self, _widgets: &[WidgetContainer], _points: Points) {}
+    fn mouse_moved_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {}
 
     /// This calls the `on_mouse_scrolled` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
     /// to honor an `on_mouse_scrolled` callback.
-    fn mouse_scrolled_callback(&mut self, _widgets: &[WidgetContainer], _points: Points) {}
+    fn mouse_scrolled_callback(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer], _points: Points) {}
 
     /// This calls the `on_button_clicked` callback.  This is implemented by the `default_widget_callbacks!` macro,
     /// so you do not need to implement it.  However, you need to call this function if you wish
@@ -145,6 +147,7 @@ pub trait Widget {
     fn button_clicked_callback(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,

--- a/src/render/widget_cache.rs
+++ b/src/render/widget_cache.rs
@@ -15,6 +15,7 @@
 
 use std::cell::RefCell;
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget::Widget;
 use crate::render::widget_config::{CONFIG_ORIGIN, CONFIG_SIZE};
 use sdl2::event::Event;
@@ -22,7 +23,6 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is a container that stores information about a `Widget` that will be drawn on the screen.
 /// It stores the `Widget` object, the actual point of origin inside the `Window` (as a `Vec<i32>`
@@ -85,10 +85,6 @@ pub struct WidgetCache {
 /// This is the `WidgetCache` implementation.  This cache object manages the `Widget` list for use by the
 /// Pushrod `Engine`.
 impl WidgetCache {
-    pub fn new() -> Self {
-        Self { cache: Vec::new() }
-    }
-
     /// This adds a `Widget` to the render list.  It requires that the `Widget` being added is in a `Box`,
     /// along with a `widget_name`.  Returns the ID of the `Widget` that was added.  Use this ID if
     /// you plan on adding further `Widget`s, with this `Widget` as the parent.  The point of
@@ -177,7 +173,14 @@ impl WidgetCache {
     /// to `false`, it indicates that the mouse button was released.  When setting the button state
     /// to `widget_id == -1`, the button click message will be sent to _all_ `Widget`s, so use
     /// `widget_id == - 1` with care.
-    pub fn button_clicked(&mut self, widget_id: i32, button: u8, clicks: u8, state: bool, cache: &[LayoutContainer]) {
+    pub fn button_clicked(
+        &mut self,
+        widget_id: i32,
+        button: u8,
+        clicks: u8,
+        state: bool,
+        cache: &[LayoutContainer],
+    ) {
         if widget_id == -1 {
             for i in 0..self.cache.len() {
                 if !self.is_hidden(i as i32) && self.is_enabled(i as i32) {

--- a/src/render/widget_cache.rs
+++ b/src/render/widget_cache.rs
@@ -22,6 +22,7 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is a container that stores information about a `Widget` that will be drawn on the screen.
 /// It stores the `Widget` object, the actual point of origin inside the `Window` (as a `Vec<i32>`
@@ -176,12 +177,13 @@ impl WidgetCache {
     /// to `false`, it indicates that the mouse button was released.  When setting the button state
     /// to `widget_id == -1`, the button click message will be sent to _all_ `Widget`s, so use
     /// `widget_id == - 1` with care.
-    pub fn button_clicked(&mut self, widget_id: i32, button: u8, clicks: u8, state: bool) {
+    pub fn button_clicked(&mut self, widget_id: i32, button: u8, clicks: u8, state: bool, cache: &[LayoutContainer]) {
         if widget_id == -1 {
             for i in 0..self.cache.len() {
                 if !self.is_hidden(i as i32) && self.is_enabled(i as i32) {
                     self.cache[i as usize].widget.borrow_mut().button_clicked(
                         &self.cache,
+                        cache,
                         button,
                         clicks,
                         state,
@@ -192,71 +194,71 @@ impl WidgetCache {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .button_clicked(&self.cache, button, clicks, state);
+                .button_clicked(&self.cache, cache, button, clicks, state);
         }
     }
 
     /// This function calls the `mouse_moved` callback for the `Widget` specified by `widget_id`.
-    pub fn mouse_moved(&mut self, widget_id: i32, points: Vec<i32>) {
+    pub fn mouse_moved(&mut self, widget_id: i32, points: Vec<i32>, cache: &[LayoutContainer]) {
         if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .mouse_moved(&self.cache, points);
+                .mouse_moved(&self.cache, cache, points);
         }
     }
 
     /// This function calls the `mouse_scrolled` callback for the `Widget` specified by `widget_id`.
-    pub fn mouse_scrolled(&mut self, widget_id: i32, points: Vec<i32>) {
+    pub fn mouse_scrolled(&mut self, widget_id: i32, points: Vec<i32>, cache: &[LayoutContainer]) {
         if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .mouse_scrolled(&self.cache, points);
+                .mouse_scrolled(&self.cache, cache, points);
         }
     }
 
     /// This function calls the `mouse_exited` callback for the `Widget` specified by `widget_id`.
-    pub fn mouse_exited(&mut self, widget_id: i32) {
+    pub fn mouse_exited(&mut self, widget_id: i32, cache: &[LayoutContainer]) {
         if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .mouse_exited(&self.cache);
+                .mouse_exited(&self.cache, cache);
         }
     }
 
     /// This function calls the `mouse_entered` callback for the `Widget` specified by `widget_id`.
-    pub fn mouse_entered(&mut self, widget_id: i32) {
+    pub fn mouse_entered(&mut self, widget_id: i32, cache: &[LayoutContainer]) {
         if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .mouse_entered(&self.cache);
+                .mouse_entered(&self.cache, cache);
         }
     }
 
     /// This function calls the `tick` method on all registered `Widget`s in the cache.  The purpose
     /// for the `tick` is to indicate that a drawing loop is about to occur, and the `Widget` can
     /// update itself as necessary beforehand.
-    pub fn tick(&mut self) {
+    pub fn tick(&mut self, _cache: &[LayoutContainer]) {
         let cache_size = self.cache.len();
 
         for i in 0..cache_size {
             if !self.is_hidden(i as i32) {
-                self.cache[i].widget.borrow_mut().tick(&self.cache);
+                self.cache[i].widget.borrow_mut().tick(&self.cache, _cache);
             }
         }
     }
 
     /// This function sends all other un-handled events from SDL2 to the currently highlighted
     /// `Widget`.
-    pub fn other_event(&mut self, widget_id: i32, event: Event) {
+    pub fn other_event(&mut self, widget_id: i32, event: Event, cache: &[LayoutContainer]) {
         if !self.is_hidden(widget_id) && self.is_enabled(widget_id) {
             self.cache[widget_id as usize]
                 .widget
                 .borrow_mut()
-                .other_event(&self.cache, event);
+                .other_event(&self.cache, cache, event);
         }
     }
 

--- a/src/render/widget_cache.rs
+++ b/src/render/widget_cache.rs
@@ -276,6 +276,12 @@ impl WidgetCache {
         }
     }
 
+    /// Returns a borrowed slice of the `WidgetContainer` `Vec` object, which can be passed on to
+    /// `Layout` objects so that the layout can be computed and performed.
+    pub fn borrow_cache(&mut self) -> &[WidgetContainer] {
+        &self.cache
+    }
+
     // Private functions
 
     fn get_children_of(&mut self, widget_id: i32) -> Vec<i32> {

--- a/src/render/widget_config.rs
+++ b/src/render/widget_config.rs
@@ -112,6 +112,19 @@ pub struct PaddingConstraint {
     pub spacing: i32,
 }
 
+/// Implementation to create a new `PaddingConstraint` object.
+impl PaddingConstraint {
+    pub fn new(top: i32, bottom: i32, left: i32, right: i32, spacing: i32) -> Self {
+        Self {
+            top,
+            bottom,
+            left,
+            right,
+            spacing,
+        }
+    }
+}
+
 /// Configuration object type - allows configurations to be set using `Piston`, `Pushrod`, or
 /// native types.
 #[derive(Clone, Debug)]

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -22,13 +22,13 @@ use crate::render::Points;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::CompassPosition::Center;
 use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/checkbox_widget.rs
+++ b/src/widgets/checkbox_widget.rs
@@ -28,11 +28,12 @@ use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.
 pub type OnToggleCallbackType =
-    Option<Box<dyn FnMut(&mut CheckboxWidget, &[WidgetContainer], bool)>>;
+    Option<Box<dyn FnMut(&mut CheckboxWidget, &[WidgetContainer], &[LayoutContainer], bool)>>;
 
 /// This is the storage object for the `CheckboxWidget`.  It stores the config, properties, callback registry.
 pub struct CheckboxWidget {
@@ -116,15 +117,15 @@ impl CheckboxWidget {
     /// Assigns the callback closure that will be used when the `Widget` toggles state.
     pub fn on_toggle<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut CheckboxWidget, &[WidgetContainer], bool) + 'static,
+        F: FnMut(&mut CheckboxWidget, &[WidgetContainer], &[LayoutContainer], bool) + 'static,
     {
         self.on_toggle = Some(Box::new(callback));
     }
 
     /// Internal function that triggers the `on_toggle` callback.
-    fn call_toggle_callback(&mut self, widgets: &[WidgetContainer]) {
+    fn call_toggle_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
         if let Some(mut cb) = self.on_toggle.take() {
-            cb(self, widgets, self.selected);
+            cb(self, widgets, layouts, self.selected);
             self.on_toggle = Some(cb);
         }
     }
@@ -162,16 +163,16 @@ impl Widget for CheckboxWidget {
     }
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.
-    fn mouse_entered(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         self.in_bounds = true;
-        self.mouse_entered_callback(_widgets);
+        self.mouse_entered_callback(_widgets, _layouts);
         self.get_config().set_invalidate(true);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.
-    fn mouse_exited(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         self.in_bounds = false;
-        self.mouse_exited_callback(_widgets);
+        self.mouse_exited_callback(_widgets, _layouts);
         self.get_config().set_invalidate(true);
     }
 
@@ -179,6 +180,7 @@ impl Widget for CheckboxWidget {
     fn button_clicked(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,
@@ -192,14 +194,14 @@ impl Widget for CheckboxWidget {
                 if self.in_bounds {
                     self.selected = !self.selected;
                     self.set_toggle(CONFIG_SELECTED_STATE, self.selected);
-                    self.call_toggle_callback(_widgets);
+                    self.call_toggle_callback(_widgets, _layouts);
                 }
             }
 
             self.get_config().set_invalidate(true);
         }
 
-        self.button_clicked_callback(_widgets, _button, _clicks, _state);
+        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     default_widget_functions!();

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -28,10 +28,11 @@ use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
-pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut ImageButtonWidget, &[WidgetContainer])>>;
+pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is the storage object for the `ImageButtonWidget`.  It stores the config, properties, callback registry.
 pub struct ImageButtonWidget {
@@ -113,15 +114,15 @@ impl ImageButtonWidget {
     /// Assigns the callback closure that will be used when a button click is triggered.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut ImageButtonWidget, &[WidgetContainer]) + 'static,
+        F: FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer]) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }
 
     /// Internal function that triggers the `on_click` callback.
-    fn call_click_callback(&mut self, widgets: &[WidgetContainer]) {
+    fn call_click_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
         if let Some(mut cb) = self.on_click.take() {
-            cb(self, widgets);
+            cb(self, widgets, layouts);
             self.on_click = Some(cb);
         }
     }
@@ -139,24 +140,24 @@ impl Widget for ImageButtonWidget {
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_entered(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_hovered();
         }
 
         self.in_bounds = true;
-        self.mouse_entered_callback(_widgets);
+        self.mouse_entered_callback(_widgets, _layouts);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_exited(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_unhovered();
         }
 
         self.in_bounds = false;
-        self.mouse_exited_callback(_widgets);
+        self.mouse_exited_callback(_widgets, _layouts);
     }
 
     /// When a mouse button is clicked within (or outside of) the bounds of the `Widget`, this
@@ -170,6 +171,7 @@ impl Widget for ImageButtonWidget {
     fn button_clicked(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,
@@ -187,12 +189,12 @@ impl Widget for ImageButtonWidget {
                 if self.in_bounds && had_bounds {
                     // Callback here
                     eprintln!("Call callback here: clicks={}", _clicks);
-                    self.call_click_callback(_widgets);
+                    self.call_click_callback(_widgets, _layouts);
                 }
             }
         }
 
-        self.button_clicked_callback(_widgets, _button, _clicks, _state);
+        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     default_widget_functions!();

--- a/src/widgets/image_button_widget.rs
+++ b/src/widgets/image_button_widget.rs
@@ -22,17 +22,18 @@ use crate::render::Points;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::CompassPosition::Center;
 use crate::widgets::image_widget::ImageWidget;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
-pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
+pub type OnClickCallbackType =
+    Option<Box<dyn FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is the storage object for the `ImageButtonWidget`.  It stores the config, properties, callback registry.
 pub struct ImageButtonWidget {

--- a/src/widgets/image_widget.rs
+++ b/src/widgets/image_widget.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use crate::render::callbacks::CallbackRegistry;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::{
     CompassPosition, Config, WidgetConfig, CONFIG_COLOR_BASE, CONFIG_IMAGE_POSITION, CONFIG_SIZE,
 };

--- a/src/widgets/image_widget.rs
+++ b/src/widgets/image_widget.rs
@@ -16,6 +16,7 @@
 use crate::render::callbacks::CallbackRegistry;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::{
     CompassPosition, Config, WidgetConfig, CONFIG_COLOR_BASE, CONFIG_IMAGE_POSITION, CONFIG_SIZE,
 };

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use crate::render::callbacks::CallbackRegistry;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::*;
 use crate::render::Points;
 

--- a/src/widgets/progress_widget.rs
+++ b/src/widgets/progress_widget.rs
@@ -16,6 +16,7 @@
 use crate::render::callbacks::CallbackRegistry;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::*;
 use crate::render::Points;
 

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -24,15 +24,16 @@ use crate::render::Points;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
-pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut PushButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
+pub type OnClickCallbackType =
+    Option<Box<dyn FnMut(&mut PushButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is the storage object for the `PushButtonWidget`.  It stores the config, properties, callback registry.
 pub struct PushButtonWidget {

--- a/src/widgets/push_button_widget.rs
+++ b/src/widgets/push_button_widget.rs
@@ -28,10 +28,11 @@ use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_click` callback is triggered from this
 /// `Widget`.
-pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut PushButtonWidget, &[WidgetContainer])>>;
+pub type OnClickCallbackType = Option<Box<dyn FnMut(&mut PushButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// This is the storage object for the `PushButtonWidget`.  It stores the config, properties, callback registry.
 pub struct PushButtonWidget {
@@ -106,15 +107,15 @@ impl PushButtonWidget {
     /// Assigns the callback closure that will be used when a button click is triggered.
     pub fn on_click<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut PushButtonWidget, &[WidgetContainer]) + 'static,
+        F: FnMut(&mut PushButtonWidget, &[WidgetContainer], &[LayoutContainer]) + 'static,
     {
         self.on_click = Some(Box::new(callback));
     }
 
     /// Internal function that triggers the `on_click` callback.
-    fn call_click_callback(&mut self, widgets: &[WidgetContainer]) {
+    fn call_click_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
         if let Some(mut cb) = self.on_click.take() {
-            cb(self, widgets);
+            cb(self, widgets, layouts);
             self.on_click = Some(cb);
         }
     }
@@ -131,24 +132,24 @@ impl Widget for PushButtonWidget {
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_entered(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_hovered();
         }
 
         self.in_bounds = true;
-        self.mouse_entered_callback(_widgets);
+        self.mouse_entered_callback(_widgets, _layouts);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
-    fn mouse_exited(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_unhovered();
         }
 
         self.in_bounds = false;
-        self.mouse_exited_callback(_widgets);
+        self.mouse_exited_callback(_widgets, _layouts);
     }
 
     /// When a mouse button is clicked within (or outside of) the bounds of the `Widget`, this
@@ -162,6 +163,7 @@ impl Widget for PushButtonWidget {
     fn button_clicked(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,
@@ -179,12 +181,12 @@ impl Widget for PushButtonWidget {
                 if self.in_bounds && had_bounds {
                     // Callback here
                     eprintln!("Call callback here: clicks={}", _clicks);
-                    self.call_click_callback(_widgets);
+                    self.call_click_callback(_widgets, _layouts);
                 }
             }
         }
 
-        self.button_clicked_callback(_widgets, _button, _clicks, _state);
+        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     default_widget_functions!();

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use crate::render::callbacks::CallbackRegistry;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
-use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::*;
 use crate::render::Points;
 

--- a/src/widgets/text_widget.rs
+++ b/src/widgets/text_widget.rs
@@ -16,6 +16,7 @@
 use crate::render::callbacks::CallbackRegistry;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
+use crate::render::layout_cache::LayoutContainer;
 use crate::render::widget_config::*;
 use crate::render::Points;
 

--- a/src/widgets/timer_widget.rs
+++ b/src/widgets/timer_widget.rs
@@ -18,14 +18,15 @@ use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::WidgetConfig;
 
+use crate::render::layout_cache::LayoutContainer;
 use std::any::Any;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_timeout` callback is triggered from this
 /// `Widget`.
-pub type TimerCallbackType = Option<Box<dyn FnMut(&mut TimerWidget, &[WidgetContainer], &[LayoutContainer])>>;
+pub type TimerCallbackType =
+    Option<Box<dyn FnMut(&mut TimerWidget, &[WidgetContainer], &[LayoutContainer])>>;
 
 /// Private function used to return the current time in milliseconds.
 fn time_ms() -> u64 {

--- a/src/widgets/toggle_button_widget.rs
+++ b/src/widgets/toggle_button_widget.rs
@@ -22,11 +22,11 @@ use crate::render::Points;
 use sdl2::render::Canvas;
 use sdl2::video::Window;
 
+use crate::render::layout_cache::LayoutContainer;
 use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
-use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.

--- a/src/widgets/toggle_button_widget.rs
+++ b/src/widgets/toggle_button_widget.rs
@@ -26,11 +26,12 @@ use crate::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
+use crate::render::layout_cache::LayoutContainer;
 
 /// This is the callback type that is used when an `on_toggle` callback is triggered from this
 /// `Widget`.
 pub type OnToggleCallbackType =
-    Option<Box<dyn FnMut(&mut ToggleButtonWidget, &[WidgetContainer], bool)>>;
+    Option<Box<dyn FnMut(&mut ToggleButtonWidget, &[WidgetContainer], &[LayoutContainer], bool)>>;
 
 /// This is the storage object for the `ToggleButtonWidget`.  It stores the config, properties, callback registry.
 pub struct ToggleButtonWidget {
@@ -149,15 +150,15 @@ impl ToggleButtonWidget {
     /// Assigns the callback closure that will be used when the `Widget` toggles state.
     pub fn on_toggle<F>(&mut self, callback: F)
     where
-        F: FnMut(&mut ToggleButtonWidget, &[WidgetContainer], bool) + 'static,
+        F: FnMut(&mut ToggleButtonWidget, &[WidgetContainer], &[LayoutContainer], bool) + 'static,
     {
         self.on_toggle = Some(Box::new(callback));
     }
 
     /// Internal function that triggers the `on_toggle` callback.
-    fn call_toggle_callback(&mut self, widgets: &[WidgetContainer]) {
+    fn call_toggle_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
         if let Some(mut cb) = self.on_toggle.take() {
-            cb(self, widgets, self.selected);
+            cb(self, widgets, layouts, self.selected);
             self.on_toggle = Some(cb);
         }
     }
@@ -174,29 +175,30 @@ impl Widget for ToggleButtonWidget {
     }
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.
-    fn mouse_entered(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_hovered();
         }
 
         self.in_bounds = true;
-        self.mouse_entered_callback(_widgets);
+        self.mouse_entered_callback(_widgets, _layouts);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.
-    fn mouse_exited(&mut self, _widgets: &[WidgetContainer]) {
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
         if self.active {
             self.draw_unhovered();
         }
 
         self.in_bounds = false;
-        self.mouse_exited_callback(_widgets);
+        self.mouse_exited_callback(_widgets, _layouts);
     }
 
     /// Overrides the `button_clicked` callback to handle toggling.
     fn button_clicked(
         &mut self,
         _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
         _button: u8,
         _clicks: u8,
         _state: bool,
@@ -211,12 +213,12 @@ impl Widget for ToggleButtonWidget {
                 if self.in_bounds {
                     self.selected = !self.selected;
                     self.set_toggle(CONFIG_SELECTED_STATE, self.selected);
-                    self.call_toggle_callback(_widgets);
+                    self.call_toggle_callback(_widgets, _layouts);
                 }
             }
         }
 
-        self.button_clicked_callback(_widgets, _button, _clicks, _state);
+        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     default_widget_functions!();


### PR DESCRIPTION
- Changed Engine to take `w, h` of screen size when initializing.
- Removed `setup` method to clean that up.
- Removed commented code from `Quit` event.
- Added `Layout` and `LayoutCache` to the `Engine` (#239)
- Modified `HorizontalLayout` so that it moves the point of origin of `Widget`s based on `Layout`'s origin.
- Added `horizontal_layout` test.
- Add `get_layout_by_id` to `LayoutCache` (#240)
- Modified `Engine` so that it handles `do_layout` as required (when `needs_layout` is set) (#232)
- Added `LayoutContainer` slices to callbacks (#242)