### PR TITLE
0.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added `fps` to `engine::new`, which enables CPU throttling for app as appropriate
 - Modified engine `run` loop to measure time flux for CPU and implements thread sleep as appropriate (#259)
 - Modified `grid` example so that the minimum is 1, not 0 (step cannot be 0 in the grid)
+- Updated documentation to fix `Engine::new` definition (#260)
+- Changed `fps` to `frame_rate` in `Engine::new`
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Modified `grid` example so that the minimum is 1, not 0 (step cannot be 0 in the grid)
 - Updated documentation to fix `Engine::new` definition (#260)
 - Changed `fps` to `frame_rate` in `Engine::new`
+- Added `ListWidget` (#255), added `list` app to show use
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.4.20
 
 - Sample applications cleanup
+- Added `fps` to `engine::new`, which enables CPU throttling for app as appropriate
+- Modified engine `run` loop to measure time flux for CPU and implements thread sleep as appropriate (#259)
+- Modified `grid` example so that the minimum is 1, not 0 (step cannot be 0 in the grid)
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.20
 
+- Sample applications cleanup
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Updated documentation to fix `Engine::new` definition (#260)
 - Changed `fps` to `frame_rate` in `Engine::new`
 - Added `ListWidget` (#255), added `list` app to show use
+- Added `append_widget()` to `Layout` trait (#261) - suggested by jbethune
+- Updated `layout` to use append_widget layout method.
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Pushrod Change Log
 
+## 0.4.20
+
+
 ## 0.4.19
 
 - Removed redraw debugging.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-pushrod"
-version = "0.4.19"
+version = "0.4.20"
 authors = ["Ken Suenobu <ksuenobu@fastmail.com>"]
 edition = "2018"
 description = "Pushrod UI Library"

--- a/README.md
+++ b/README.md
@@ -39,12 +39,10 @@ Soon to follow will be:
 - [ ] Simple Popup Menu Widget
 - [ ] Drop Down Menu Widget
 - [ ] Drop Down Menu Button Widget
-- [ ] Grid Widget
 - [ ] Toolbox Widget
 - [ ] Tab Widget
 - [ ] Group Box Widget
 - [ ] Split Container Widget
-- [ ] Slider Widget
 - [ ] Viewport Widget that adjusts a viewable area with scrolling
 
 ## Additional Items
@@ -62,6 +60,8 @@ Soon to follow will be:
 - [x] Image Button Widget
 - [x] Toggle Button Widget
 - [x] Checkbox Widget
+- [x] Slider Widget
+- [x] Grid Widget
 - [x] Fix build so that it builds on TravisCI for both OSes properly
 - [x] New traits for optimization:
   - [x] `Drawable`
@@ -94,8 +94,6 @@ Soon to follow will be:
 - [ ] `PageWidget`: page controller to contain and swap displays of different pages of containers
 - [ ] `GridLayoutContainer`: layout objects equally sized in a grid
 - [ ] `ToolboxWidget`: layout that displays clickable images and captioned text
-- [ ] `HorizontalSpaceWidget`: horizontal spacer for layout containers
-- [ ] `VerticalSpaceWidget`: vertical spacer for layout containers
 - [ ] `DropdownMenuWidget`: displays a dropdown menu with selectable items in a list
 - [ ] `SplitContainerWidget`: splits two displays horizontally or vertically by a resizable spacer
 - [ ] `GridWidget`: displays a grid (either by lines or dots) evenly spaced by a grid snap offset

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -2,10 +2,7 @@ extern crate pushrod;
 extern crate sdl2;
 
 use pushrod::render::engine::Engine;
-use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::checkbox_widget::*;
-use sdl2::pixels::Color;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();

--- a/examples/checkbox.rs
+++ b/examples/checkbox.rs
@@ -13,7 +13,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 180);
+    let mut engine = Engine::new(400, 180, 60);
     let widget1 = CheckboxWidget::new(20, 20, 360, 30, String::from(" Checkbox Item 1"), 22, false);
     let widget2 = CheckboxWidget::new(20, 70, 360, 30, String::from(" Checked Checkbox"), 22, true);
     let widget3 = CheckboxWidget::new(

--- a/examples/grid.rs
+++ b/examples/grid.rs
@@ -6,7 +6,6 @@ use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
 use pushrod::render::widget_config::{CONFIG_BORDER_WIDTH, CONFIG_COLOR_BORDER, CONFIG_COLOR_TEXT};
 use pushrod::widgets::grid_widget::GridWidget;
-use pushrod::widgets::push_button_widget::PushButtonWidget;
 use pushrod::widgets::slider_widget::SliderOrientation::SliderHorizontal;
 use pushrod::widgets::slider_widget::SliderWidget;
 use pushrod::widgets::text_widget::{TextJustify, TextWidget};

--- a/examples/grid.rs
+++ b/examples/grid.rs
@@ -37,7 +37,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 340);
+    let mut engine = Engine::new(400, 340, 60);
     let mut grid1 = GridWidget::new(20, 20, 360, 280, 10);
 
     grid1
@@ -45,7 +45,7 @@ pub fn main() {
         .set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     grid1.get_config().set_numeric(CONFIG_BORDER_WIDTH, 1);
 
-    let mut slider1 = SliderWidget::new(20, 310, 320, 20, 0, 30, 10, SliderHorizontal);
+    let mut slider1 = SliderWidget::new(20, 310, 320, 20, 1, 20, 10, SliderHorizontal);
 
     slider1.on_value_changed(|_slider, _widgets, _layouts, pos| {
         let text1_id = widget_id_for_name(_widgets, String::from("text1"));

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -19,7 +19,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(WIDTH, HEIGHT);
+    let mut engine = Engine::new(WIDTH, HEIGHT, 60);
     let mut widget1 =
         ImageWidget::new(String::from("assets/rust-48x48.jpg"), 20, 16, 60, 60, false);
 

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -13,7 +13,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 180);
+    let mut engine = Engine::new(400, 180, 60);
     let widget1 = ImageButtonWidget::new(
         20,
         20,

--- a/examples/image_button.rs
+++ b/examples/image_button.rs
@@ -2,10 +2,7 @@ extern crate pushrod;
 extern crate sdl2;
 
 use pushrod::render::engine::Engine;
-use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::image_button_widget::*;
-use sdl2::pixels::Color;
 
 pub fn main() {
     let sdl_context = sdl2::init().unwrap();

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -75,10 +75,10 @@ pub fn main() {
     let widget3_id = engine.add_widget(Box::new(widget3), String::from("widget3"));
     let widget4_id = engine.add_widget(Box::new(widget4), String::from("widget4"));
 
-    layout.insert_widget(widget1_id, LayoutPosition::new(0, 0));
-    layout.insert_widget(widget2_id, LayoutPosition::new(1, 0));
-    layout2.insert_widget(widget3_id, LayoutPosition::new(0, 0));
-    layout2.insert_widget(widget4_id, LayoutPosition::new(0, 1));
+    layout.append_widget(widget1_id);
+    layout.append_widget(widget2_id);
+    layout2.append_widget(widget3_id);
+    layout2.append_widget(widget4_id);
     engine.add_layout(Box::new(layout));
     engine.add_layout(Box::new(layout2));
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -38,7 +38,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 300);
+    let mut engine = Engine::new(400, 300, 60);
     let mut layout = HorizontalLayout::new(20, 20, 360, 80, PaddingConstraint::new(0, 0, 0, 0, 1));
     let mut layout2 =
         VerticalLayout::new(250, 120, 130, 160, PaddingConstraint::new(0, 0, 0, 0, 1));

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -75,10 +75,10 @@ pub fn main() {
     let widget3_id = engine.add_widget(Box::new(widget3), String::from("widget3"));
     let widget4_id = engine.add_widget(Box::new(widget4), String::from("widget4"));
 
-    layout.add_widget(widget1_id, LayoutPosition::new(0, 0));
-    layout.add_widget(widget2_id, LayoutPosition::new(1, 0));
-    layout2.add_widget(widget3_id, LayoutPosition::new(0, 0));
-    layout2.add_widget(widget4_id, LayoutPosition::new(0, 1));
+    layout.insert_widget(widget1_id, LayoutPosition::new(0, 0));
+    layout.insert_widget(widget2_id, LayoutPosition::new(1, 0));
+    layout2.insert_widget(widget3_id, LayoutPosition::new(0, 0));
+    layout2.insert_widget(widget4_id, LayoutPosition::new(0, 1));
     engine.add_layout(Box::new(layout));
     engine.add_layout(Box::new(layout2));
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -9,14 +9,11 @@ use pushrod::render::layout::{Layout, LayoutPosition};
 use pushrod::render::widget::{BaseWidget, Widget};
 use pushrod::render::widget_cache::WidgetContainer;
 use pushrod::render::widget_config::{
-    PaddingConstraint, CONFIG_BORDER_WIDTH, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER,
-    CONFIG_COLOR_SECONDARY, CONFIG_COLOR_TEXT,
+    PaddingConstraint, CONFIG_BORDER_WIDTH, CONFIG_COLOR_BORDER, CONFIG_COLOR_TEXT,
 };
-use pushrod::widgets::progress_widget::*;
 use pushrod::widgets::push_button_widget::PushButtonWidget;
 use pushrod::widgets::text_widget::{TextJustify, TextWidget};
 use sdl2::pixels::Color;
-use std::fmt::Display;
 
 #[macro_export]
 macro_rules! cast {
@@ -121,7 +118,7 @@ pub fn main() {
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button1.on_click(|x, _widgets, _layouts| {
+    button1.on_click(|_, _widgets, _layouts| {
         let mut spacing = _layouts[0].layout.borrow_mut().get_padding().spacing - 1;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -153,7 +150,7 @@ pub fn main() {
 
     button2.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button2.on_click(|x, _widgets, _layouts| {
+    button2.on_click(|_, _widgets, _layouts| {
         let mut spacing = _layouts[0].layout.borrow_mut().get_padding().spacing + 1;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -217,7 +214,7 @@ pub fn main() {
 
     button3.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button3.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button3.on_click(|x, _widgets, _layouts| {
+    button3.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let mut top = _layouts[0].layout.borrow_mut().get_padding().top - 1;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -249,7 +246,7 @@ pub fn main() {
 
     button4.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button4.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button4.on_click(|x, _widgets, _layouts| {
+    button4.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let mut top = _layouts[0].layout.borrow_mut().get_padding().top + 1;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -313,7 +310,7 @@ pub fn main() {
 
     button5.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button5.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button5.on_click(|x, _widgets, _layouts| {
+    button5.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let mut bottom = _layouts[0].layout.borrow_mut().get_padding().bottom - 1;
@@ -345,7 +342,7 @@ pub fn main() {
 
     button6.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button6.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button6.on_click(|x, _widgets, _layouts| {
+    button6.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let mut bottom = _layouts[0].layout.borrow_mut().get_padding().bottom + 1;
@@ -409,7 +406,7 @@ pub fn main() {
 
     button7.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button7.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button7.on_click(|x, _widgets, _layouts| {
+    button7.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -441,7 +438,7 @@ pub fn main() {
 
     button8.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button8.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button8.on_click(|x, _widgets, _layouts| {
+    button8.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -505,7 +502,7 @@ pub fn main() {
 
     button9.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button9.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button9.on_click(|x, _widgets, _layouts| {
+    button9.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;
@@ -537,7 +534,7 @@ pub fn main() {
 
     button10.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button10.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button10.on_click(|x, _widgets, _layouts| {
+    button10.on_click(|_, _widgets, _layouts| {
         let spacing = _layouts[0].layout.borrow_mut().get_padding().spacing;
         let top = _layouts[0].layout.borrow_mut().get_padding().top;
         let bottom = _layouts[0].layout.borrow_mut().get_padding().bottom;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -3,7 +3,10 @@ extern crate sdl2;
 
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH, CONFIG_COLOR_HOVER};
+use pushrod::render::widget_config::{
+    CONFIG_BORDER_WIDTH, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER, CONFIG_COLOR_HOVER,
+    CONFIG_COLOR_SECONDARY,
+};
 use pushrod::widgets::list_widget::*;
 use sdl2::pixels::Color;
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,0 +1,40 @@
+extern crate pushrod;
+extern crate sdl2;
+
+use pushrod::render::engine::Engine;
+use pushrod::render::widget::Widget;
+use pushrod::render::widget_config::{CONFIG_COLOR_SECONDARY, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER, CONFIG_BORDER_WIDTH, CONFIG_COLOR_HOVER};
+use pushrod::widgets::list_widget::*;
+use sdl2::pixels::Color;
+
+pub fn main() {
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let window = video_subsystem
+        .window("pushrod-render list demo", 400, 300)
+        .position_centered()
+        .opengl()
+        .build()
+        .unwrap();
+    let mut engine = Engine::new(400, 300, 60);
+    let mut widget1 = ListWidget::new(20, 20, 200, 260);
+
+    widget1.set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+    widget1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
+    widget1.set_color(CONFIG_COLOR_HOVER, Color::RGB(0x90, 0x90, 0xFF));
+    widget1.set_numeric(CONFIG_BORDER_WIDTH, 1);
+
+    widget1.add_item(String::from("Item 1"));
+    widget1.add_item(String::from("Item 2"));
+    widget1.add_item(String::from("Item 3"));
+    widget1.add_item(String::from("Item 4"));
+    widget1.add_item(String::from("Item 5"));
+
+    widget1.on_selected(|x, _widgets, _layout, selected_item| {
+        eprintln!("Selected: {}", selected_item);
+    });
+
+    engine.add_widget(Box::new(widget1), String::from("widget1"));
+
+    engine.run(sdl_context, window);
+}

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 180);
+    let mut engine = Engine::new(400, 180, 60);
     let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));

--- a/examples/push_button.rs
+++ b/examples/push_button.rs
@@ -21,7 +21,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 100);
+    let mut engine = Engine::new(400, 100, 30);
     let mut button1 = PushButtonWidget::new(20, 20, 360, 60, String::from("Click me!"), 40);
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -20,7 +20,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(800, 600);
+    let mut engine = Engine::new(800, 600, 30);
     let mut new_base_widget = BaseWidget::new(100, 100, 600, 400);
 
     new_base_widget

--- a/examples/slider.rs
+++ b/examples/slider.rs
@@ -36,7 +36,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 300);
+    let mut engine = Engine::new(400, 300, 60);
     let mut slider1 = SliderWidget::new(20, 20, 300, 20, 0, 100, 20, SliderHorizontal);
 
     slider1.on_value_changed(|_slider, _widgets, _layouts, pos| {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -16,7 +16,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(500, 200);
+    let mut engine = Engine::new(500, 200, 20);
     let mut widget1 = TextWidget::new(
         String::from("assets/OpenSans-Regular.ttf"),
         sdl2::ttf::FontStyle::NORMAL,

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -4,13 +4,10 @@ extern crate sdl2;
 use pushrod::render::callbacks::widget_id_for_name;
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget::*;
 use pushrod::render::widget_config::CONFIG_COLOR_SECONDARY;
 use pushrod::widgets::progress_widget::*;
-use pushrod::widgets::text_widget::TextWidget;
 use pushrod::widgets::timer_widget::*;
 use sdl2::pixels::Color;
-use std::any::Any;
 
 #[macro_export]
 macro_rules! cast {
@@ -47,7 +44,7 @@ pub fn main() {
     widget3.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));
 
     let mut timer = TimerWidget::new(100, true);
-    timer.on_timeout(|x, _widgets, _layouts| {
+    timer.on_timeout(|_, _widgets, _layouts| {
         let widget1_id = widget_id_for_name(_widgets, String::from("widget1"));
         let widget2_id = widget_id_for_name(_widgets, String::from("widget2"));
         let widget3_id = widget_id_for_name(_widgets, String::from("widget3"));

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -30,7 +30,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 180);
+    let mut engine = Engine::new(400, 180, 30);
     let mut widget1 = ProgressWidget::new(20, 20, 360, 40, 25);
 
     widget1.set_color(CONFIG_COLOR_SECONDARY, Color::RGB(255, 0, 0));

--- a/examples/toggle_button.rs
+++ b/examples/toggle_button.rs
@@ -21,7 +21,7 @@ pub fn main() {
         .opengl()
         .build()
         .unwrap();
-    let mut engine = Engine::new(400, 100);
+    let mut engine = Engine::new(400, 100, 60);
     let mut button1 = ToggleButtonWidget::new(20, 20, 170, 60, String::from("1"), 40, false);
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));

--- a/examples/toggle_button.rs
+++ b/examples/toggle_button.rs
@@ -3,7 +3,7 @@ extern crate sdl2;
 
 use pushrod::render::engine::Engine;
 use pushrod::render::widget::Widget;
-use pushrod::render::widget_config::{CONFIG_BORDER_WIDTH, CONFIG_COLOR_BASE, CONFIG_COLOR_BORDER};
+use pushrod::render::widget_config::{CONFIG_BORDER_WIDTH, CONFIG_COLOR_BORDER};
 use pushrod::widgets::toggle_button_widget::ToggleButtonWidget;
 use sdl2::pixels::Color;
 
@@ -26,7 +26,7 @@ pub fn main() {
 
     button1.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button1.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button1.on_toggle(|x, _widgets, _layouts, _state| {
+    button1.on_toggle(|_, _widgets, _layouts, _state| {
         eprintln!("1 Toggled: {}", _state);
     });
 
@@ -34,7 +34,7 @@ pub fn main() {
 
     button2.set_color(CONFIG_COLOR_BORDER, Color::RGB(0, 0, 0));
     button2.set_numeric(CONFIG_BORDER_WIDTH, 2);
-    button2.on_toggle(|x, _widgets, _layouts, _state| {
+    button2.on_toggle(|_, _widgets, _layouts, _state| {
         eprintln!("2 Toggled: {}", _state);
     });
 

--- a/src/layouts/horizontal_layout.rs
+++ b/src/layouts/horizontal_layout.rs
@@ -47,10 +47,22 @@ impl HorizontalLayout {
 /// added to the bounds of the `Layout`.
 impl Layout for HorizontalLayout {
     /// Adds a widget to the `HorizontalLayout` managed stack.
-    fn add_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
+    fn insert_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
         self.widget_ids.push(widget_id);
         self.widget_positions.push(widget_position);
         self.invalidated = true;
+    }
+
+    /// Appends a widget to the `HorizontalLayout` managed stack.
+    fn append_widget(&mut self, widget_id: i32) {
+        let positions = self.widget_positions.len();
+        let widget_position = if self.widget_positions.is_empty() {
+            LayoutPosition::new(0, 0)
+        } else {
+            LayoutPosition::new(0, self.widget_positions[positions - 1].y + 1)
+        };
+
+        self.insert_widget(widget_id, widget_position);
     }
 
     fn set_padding(&mut self, padding: PaddingConstraint) {

--- a/src/layouts/vertical_layout.rs
+++ b/src/layouts/vertical_layout.rs
@@ -47,10 +47,22 @@ impl VerticalLayout {
 /// added to the bounds of the `Layout`.
 impl Layout for VerticalLayout {
     /// Adds a widget to the `VerticalLayout` managed stack.
-    fn add_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
+    fn insert_widget(&mut self, widget_id: i32, widget_position: LayoutPosition) {
         self.widget_ids.push(widget_id);
         self.widget_positions.push(widget_position);
         self.invalidated = true;
+    }
+
+    /// Appends a widget to the `VerticalLayout` managed stack.
+    fn append_widget(&mut self, widget_id: i32) {
+        let positions = self.widget_positions.len();
+        let widget_position = if self.widget_positions.is_empty() {
+            LayoutPosition::new(0, 0)
+        } else {
+            LayoutPosition::new(self.widget_positions[positions - 1].x + 1, 0)
+        };
+
+        self.insert_widget(widget_id, widget_position);
     }
 
     fn set_padding(&mut self, padding: PaddingConstraint) {

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -29,7 +29,7 @@ pub struct Engine {
     widget_cache: WidgetCache,
     layout_cache: LayoutCache,
     current_widget_id: i32,
-    fps: u8,
+    frame_rate: u8,
     running: bool,
 }
 
@@ -38,7 +38,7 @@ pub struct Engine {
 /// follows:
 ///
 /// ## Create a new object
-/// Use `Engine::new()` to instantiate a new object.
+/// Use `Engine::new(w, h, frame_rate)` to instantiate a new object.
 ///
 /// ## Set up the base
 /// Call `engine.setup(width, height)`, by passing the width and height of the window that is
@@ -56,11 +56,14 @@ pub struct Engine {
 /// That's all there is to it.  If you want to see more interactions on how the `Engine` is used in
 /// an application, check out the demo test code, and look at `rust-pushrod-chassis`.
 impl Engine {
-    /// Creates a new `Engine` object.  Sets the engine up with the bounds of the screen, which
-    /// must be provided at instantiation time.  This is in order to set up the `BaseWidget` in the
-    /// top-level of the `Engine`, so that it knows what area of the screen to refresh when
-    /// required as part of the draw cycle.
-    pub fn new(w: u32, h: u32, fps: u8) -> Self {
+    /// Creates a new `Engine` object.  Sets the engine up with the bounds of the screen, and the desired
+    /// FPS rate, which must be provided at instantiation time.  This is in order to set up the
+    /// `BaseWidget` in the top-level of the `Engine`, so that it knows what area of the screen to
+    /// refresh when required as part of the draw cycle.
+    ///
+    /// **NOTE**: Setting a lower frame_rate will increase the efficiency of your API, however, it
+    /// could lower responsiveness if you have a very active UI.
+    pub fn new(w: u32, h: u32, frame_rate: u8) -> Self {
         let base_widget = BaseWidget::new(0, 0, w, h);
         let mut cache = WidgetCache::default();
 
@@ -70,7 +73,7 @@ impl Engine {
             widget_cache: cache,
             layout_cache: LayoutCache::default(),
             current_widget_id: 0,
-            fps,
+            frame_rate,
             running: true,
         }
     }
@@ -99,7 +102,7 @@ impl Engine {
         canvas.present();
 
         let mut event_pump = sdl.event_pump().unwrap();
-        let fps_as_ms = (1000.0 / self.fps as f64) as u128;
+        let fps_as_ms = (1000.0 / self.frame_rate as f64) as u128;
 
         'running: loop {
             let start = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -21,8 +21,8 @@ use crate::render::layout::Layout;
 use crate::render::layout_cache::LayoutCache;
 use crate::render::widget::{BaseWidget, Widget};
 use crate::render::widget_cache::WidgetCache;
-use std::time::{Duration, UNIX_EPOCH, SystemTime};
 use std::thread::sleep;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// This is a storage container for the Pushrod event engine.
 pub struct Engine {
@@ -105,7 +105,10 @@ impl Engine {
         let fps_as_ms = (1000.0 / self.frame_rate as f64) as u128;
 
         'running: loop {
-            let start = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+            let start = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
 
             for event in event_pump.poll_iter() {
                 match event {
@@ -182,7 +185,10 @@ impl Engine {
             self.widget_cache.draw_loop(&mut canvas);
 
             // This obeys thread sleep time.
-            let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
 
             if now - start < fps_as_ms {
                 let diff = fps_as_ms - (now - start);

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -21,13 +21,15 @@ use crate::render::layout::Layout;
 use crate::render::layout_cache::LayoutCache;
 use crate::render::widget::{BaseWidget, Widget};
 use crate::render::widget_cache::WidgetCache;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH, SystemTime};
+use std::thread::sleep;
 
 /// This is a storage container for the Pushrod event engine.
 pub struct Engine {
     widget_cache: WidgetCache,
     layout_cache: LayoutCache,
     current_widget_id: i32,
+    fps: u8,
     running: bool,
 }
 
@@ -58,7 +60,7 @@ impl Engine {
     /// must be provided at instantiation time.  This is in order to set up the `BaseWidget` in the
     /// top-level of the `Engine`, so that it knows what area of the screen to refresh when
     /// required as part of the draw cycle.
-    pub fn new(w: u32, h: u32) -> Self {
+    pub fn new(w: u32, h: u32, fps: u8) -> Self {
         let base_widget = BaseWidget::new(0, 0, w, h);
         let mut cache = WidgetCache::default();
 
@@ -68,6 +70,7 @@ impl Engine {
             widget_cache: cache,
             layout_cache: LayoutCache::default(),
             current_widget_id: 0,
+            fps,
             running: true,
         }
     }
@@ -96,8 +99,11 @@ impl Engine {
         canvas.present();
 
         let mut event_pump = sdl.event_pump().unwrap();
+        let fps_as_ms = (1000.0 / self.fps as f64) as u128;
 
         'running: loop {
+            let start = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+
             for event in event_pump.poll_iter() {
                 match event {
                     Event::MouseButtonDown {
@@ -172,7 +178,14 @@ impl Engine {
                 .do_layout(self.widget_cache.borrow_cache());
             self.widget_cache.draw_loop(&mut canvas);
 
-            ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
+            // This obeys thread sleep time.
+            let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+
+            if now - start < fps_as_ms {
+                let diff = fps_as_ms - (now - start);
+
+                sleep(Duration::from_millis(diff as u64));
+            }
 
             if !self.running {
                 break 'running;

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -37,7 +37,12 @@ impl LayoutPosition {
 pub trait Layout {
     /// Adds a `Widget` by ID to the `Layout` manager, given its `LayoutPosition`, as a position
     /// marker in the manager.
-    fn add_widget(&mut self, _widget_id: i32, _widget_position: LayoutPosition);
+    fn insert_widget(&mut self, _widget_id: i32, _widget_position: LayoutPosition);
+
+    /// Adds a `Widget` by ID to the `Layout` manager, automatically adding it to the next available
+    /// `LayoutPosition`.  Use this as a way to add a widget if you don't need to specify a
+    /// `LayoutPosition`.
+    fn append_widget(&mut self, _widget_id: i32);
 
     /// Changes the `PaddingConstraint` for this `Layout`.
     fn set_padding(&mut self, padding: PaddingConstraint);

--- a/src/widgets/list_widget.rs
+++ b/src/widgets/list_widget.rs
@@ -1,0 +1,371 @@
+// Pushrod Widget Library
+// List Widget
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::render::callbacks::CallbackRegistry;
+use crate::render::widget::*;
+use crate::render::widget_cache::WidgetContainer;
+use crate::render::widget_config::*;
+use crate::render::{Points, POINT_X, POINT_Y, SIZE_HEIGHT, SIZE_WIDTH};
+
+use sdl2::render::Canvas;
+use sdl2::video::Window;
+
+use crate::render::layout_cache::LayoutContainer;
+use crate::widgets::slider_widget::SliderOrientation::{SliderHorizontal, SliderVertical};
+use sdl2::pixels::Color;
+use sdl2::rect::{Point, Rect};
+use std::any::Any;
+use std::collections::HashMap;
+
+///// This is the callback type that is used when an `on_value_changed` callback is triggered from this
+///// `Widget`.
+//pub type OnValueChangedCallbackType =
+//Option<Box<dyn FnMut(&mut SliderWidget, &[WidgetContainer], &[LayoutContainer], u32)>>;
+//
+///// These are the possible slider orientations.
+//#[derive(PartialEq)]
+//pub enum SliderOrientation {
+//    /// Indicates a horizontally controllable slider.
+//    SliderHorizontal,
+//
+//    /// Indicates a vertically controllable slider.
+//    SliderVertical,
+//}
+
+/// This is the storage object for the `ListWidget`.  It stores the config, properties, callback registry.
+pub struct ListWidget {
+    config: WidgetConfig,
+    system_properties: HashMap<i32, String>,
+    callback_registry: CallbackRegistry,
+    list_items: Vec<String>,
+}
+
+/// This is the implementation of the `ListWidget`, a control that draws a bounds line indicator, and a
+/// draggable slider.
+impl ListWidget {
+    /// Creates a new `SliderWidget` given the `x, y, w, h` coordinates, sets the `min` and `max` values,
+    /// the `current` value, and the `orientation` of the slider as drawn.
+    pub fn new(
+        x: i32,
+        y: i32,
+        w: u32,
+        h: u32,
+    ) -> Self {
+        Self {
+            config: WidgetConfig::new(x, y, w, h),
+            system_properties: HashMap::new(),
+            callback_registry: CallbackRegistry::new(),
+            list_items: vec![],
+        }
+    }
+
+//    /// Assigns the callback closure that will be used when the `Widget` changes value.
+//    pub fn on_value_changed<F>(&mut self, callback: F)
+//        where
+//            F: FnMut(&mut SliderWidget, &[WidgetContainer], &[LayoutContainer], u32) + 'static,
+//    {
+//        self.on_value_changed = Some(Box::new(callback));
+//    }
+//
+//    /// Internal function that triggers the `on_value_changed` callback.
+//    fn call_value_changed_callback(
+//        &mut self,
+//        widgets: &[WidgetContainer],
+//        layouts: &[LayoutContainer],
+//    ) {
+//        if let Some(mut cb) = self.on_value_changed.take() {
+//            cb(self, widgets, layouts, self.current);
+//            self.on_value_changed = Some(cb);
+//        }
+//    }
+}
+
+/// This is the `Widget` implementation of the `ListWidget`.
+impl Widget for ListWidget {
+    /// Draws the `ListWidget` contents.
+    fn draw(&mut self, c: &mut Canvas<Window>) {
+        let base_color = self.get_color(CONFIG_COLOR_BASE);
+
+        c.set_draw_color(base_color);
+        c.fill_rect(self.get_drawing_area()).unwrap();
+
+        let border_color = self.get_config().get_color(CONFIG_COLOR_BORDER);
+
+        if self.get_config().get_numeric(CONFIG_BORDER_WIDTH) > 0 && base_color != border_color {
+            c.set_draw_color(border_color);
+
+            for border in 0..self.get_config().get_numeric(CONFIG_BORDER_WIDTH) {
+                c.draw_rect(Rect::new(
+                    self.config.to_x(border),
+                    self.config.to_y(border),
+                    self.get_config().get_size(CONFIG_SIZE)[0] - (border as u32 * 2),
+                    self.get_config().get_size(CONFIG_SIZE)[1] - (border as u32 * 2),
+                ))
+                    .unwrap();
+            }
+        }
+
+//        if self.orientation == SliderHorizontal {
+//            let base_color = self.get_color(CONFIG_COLOR_BASE);
+//
+//            c.set_draw_color(base_color);
+//            c.fill_rect(self.get_drawing_area()).unwrap();
+//
+//            // Draw base - three lines in the center
+//            let half_height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT] / 2) as i32;
+//            let width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH]) as i32;
+//
+//            c.set_draw_color(Color::RGB(192, 192, 192));
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(0),
+//                    self.get_config().to_y(half_height),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(width),
+//                    self.get_config().to_y(half_height),
+//                ),
+//            )
+//                .unwrap();
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(0),
+//                    self.get_config().to_y(half_height - 1),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(width),
+//                    self.get_config().to_y(half_height - 1),
+//                ),
+//            )
+//                .unwrap();
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(0),
+//                    self.get_config().to_y(half_height + 1),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(width),
+//                    self.get_config().to_y(half_height + 1),
+//                ),
+//            )
+//                .unwrap();
+//
+//            // Draw slider at current value
+//            let full_range = self.max - self.min;
+//            let slider_center =
+//                ((width as f64 / full_range as f64) * (self.current - self.min) as f64) as u32;
+//            let slider_start = if slider_center >= width as u32 - 15 {
+//                width as u32 - 30
+//            } else if slider_center <= 15 {
+//                0
+//            } else {
+//                slider_center - 15
+//            };
+//
+//            c.set_draw_color(base_color);
+//            c.fill_rect(Rect::new(
+//                self.get_config().to_x(slider_start as i32),
+//                self.get_config().to_y(0),
+//                30,
+//                self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT],
+//            ))
+//                .unwrap();
+//
+//            c.set_draw_color(Color::RGB(0, 0, 0));
+//            c.draw_rect(Rect::new(
+//                self.get_config().to_x(slider_start as i32),
+//                self.get_config().to_y(0),
+//                30,
+//                self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT],
+//            ))
+//                .unwrap();
+//        } else if self.orientation == SliderVertical {
+//            let base_color = self.get_color(CONFIG_COLOR_BASE);
+//
+//            c.set_draw_color(base_color);
+//            c.fill_rect(self.get_drawing_area()).unwrap();
+//
+//            // Draw base - three lines in the center
+//            let half_width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH] / 2) as i32;
+//            let height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT]) as i32;
+//
+//            c.set_draw_color(Color::RGB(192, 192, 192));
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(half_width),
+//                    self.get_config().to_y(0),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(half_width),
+//                    self.get_config().to_y(height),
+//                ),
+//            )
+//                .unwrap();
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(half_width - 1),
+//                    self.get_config().to_y(0),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(half_width - 1),
+//                    self.get_config().to_y(height),
+//                ),
+//            )
+//                .unwrap();
+//            c.draw_line(
+//                Point::new(
+//                    self.get_config().to_x(half_width + 1),
+//                    self.get_config().to_y(0),
+//                ),
+//                Point::new(
+//                    self.get_config().to_x(half_width + 1),
+//                    self.get_config().to_y(height),
+//                ),
+//            )
+//                .unwrap();
+//
+//            // Draw slider at current value
+//            let full_range = self.max - self.min;
+//            let slider_center =
+//                ((height as f64 / full_range as f64) * (self.current - self.min) as f64) as u32;
+//            let slider_start = if slider_center >= height as u32 - 15 {
+//                height as u32 - 30
+//            } else if slider_center <= 15 {
+//                0
+//            } else {
+//                slider_center - 15
+//            };
+//
+//            c.set_draw_color(base_color);
+//            c.fill_rect(Rect::new(
+//                self.get_config().to_x(0),
+//                self.get_config().to_y(slider_start as i32),
+//                self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH],
+//                30,
+//            ))
+//                .unwrap();
+//
+//            c.set_draw_color(Color::RGB(0, 0, 0));
+//            c.draw_rect(Rect::new(
+//                self.get_config().to_x(0),
+//                self.get_config().to_y(slider_start as i32),
+//                self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH],
+//                30,
+//            ))
+//                .unwrap();
+//        }
+    }
+
+    /// When a mouse enters the bounds of the `Widget`, this function is triggered.
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+//        self.in_bounds = true;
+    }
+
+    /// When a mouse exits the bounds of the `Widget`, this function is triggered.
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+//        self.in_bounds = false;
+    }
+
+    /// When a mouse is moved in the bounds of this `Widget`, this function is triggered.
+    fn mouse_moved(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        points: Points,
+    ) {
+//        if self.in_bounds && self.active && self.originated {
+//            if self.orientation == SliderHorizontal {
+//                let width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH]) as i32;
+//                let position_x =
+//                    points[POINT_X] - self.get_config().get_point(CONFIG_ORIGIN)[POINT_X] as i32;
+//                let percentage = position_x as f64 / width as f64;
+//                let full_range = self.max - self.min;
+//                let actual = (percentage * full_range as f64) as u32;
+//
+//                self.current = self.min + actual;
+//
+//                self.get_config().set_invalidated(true);
+//                self.call_value_changed_callback(_widgets, _layouts);
+//            } else if self.orientation == SliderVertical {
+//                let height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT]) as i32;
+//                let position_y =
+//                    points[POINT_Y] - self.get_config().get_point(CONFIG_ORIGIN)[POINT_Y] as i32;
+//                let percentage = position_y as f64 / height as f64;
+//                let full_range = self.max - self.min;
+//                let actual = (percentage * full_range as f64) as u32;
+//
+//                self.current = self.min + actual;
+//
+//                self.get_config().set_invalidated(true);
+//                self.call_value_changed_callback(_widgets, _layouts);
+//            }
+//        }
+    }
+
+    /// Handles the scrolling functionality.
+    fn mouse_scrolled(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        points: Points,
+    ) {
+//        let mut current_i32 = self.current as i32;
+//
+//        if self.orientation == SliderHorizontal {
+//            current_i32 += points[POINT_X];
+//        } else if self.orientation == SliderVertical {
+//            current_i32 += -points[POINT_Y];
+//        }
+//
+//        if current_i32 >= self.max as i32 {
+//            current_i32 = self.max as i32;
+//        } else if current_i32 <= self.min as i32 {
+//            current_i32 = self.min as i32;
+//        }
+//
+//        self.current = current_i32 as u32;
+//
+//        self.get_config().set_invalidated(true);
+//        self.call_value_changed_callback(_widgets, _layouts);
+    }
+
+    /// Overrides the `button_clicked` callback to handle toggling.
+    fn button_clicked(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _button: u8,
+        _clicks: u8,
+        _state: bool,
+    ) {
+//        if _button == 1 {
+//            if _state {
+//                self.active = true;
+//                self.originated = true;
+//            } else {
+//                self.active = false;
+//                self.originated = false;
+//            }
+//
+//            self.get_config().set_invalidated(true);
+//        }
+//
+//        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
+    }
+
+    default_widget_functions!();
+    default_widget_properties!();
+    default_widget_callbacks!();
+}

--- a/src/widgets/list_widget.rs
+++ b/src/widgets/list_widget.rs
@@ -71,6 +71,15 @@ impl ListWidget {
         }
     }
 
+    /// Adds a text item to the `ListWidget`.
+    pub fn add_item(&mut self, item: String) -> usize {
+        let item_size = self.list_items.len() + 1;
+
+        self.list_items.push(item.clone());
+
+        item_size
+    }
+
 //    /// Assigns the callback closure that will be used when the `Widget` changes value.
 //    pub fn on_value_changed<F>(&mut self, callback: F)
 //        where

--- a/src/widgets/list_widget.rs
+++ b/src/widgets/list_widget.rs
@@ -17,32 +17,23 @@ use crate::render::callbacks::CallbackRegistry;
 use crate::render::widget::*;
 use crate::render::widget_cache::WidgetContainer;
 use crate::render::widget_config::*;
-use crate::render::{Points, POINT_X, POINT_Y, SIZE_HEIGHT, SIZE_WIDTH};
 
-use sdl2::render::Canvas;
+use sdl2::render::{Canvas, TextureQuery};
 use sdl2::video::Window;
 
 use crate::render::layout_cache::LayoutContainer;
 use crate::widgets::slider_widget::SliderOrientation::{SliderHorizontal, SliderVertical};
-use sdl2::pixels::Color;
 use sdl2::rect::{Point, Rect};
 use std::any::Any;
 use std::collections::HashMap;
+use std::path::Path;
+use sdl2::pixels::Color;
+use crate::render::{Points, POINT_Y};
 
-///// This is the callback type that is used when an `on_value_changed` callback is triggered from this
-///// `Widget`.
-//pub type OnValueChangedCallbackType =
-//Option<Box<dyn FnMut(&mut SliderWidget, &[WidgetContainer], &[LayoutContainer], u32)>>;
-//
-///// These are the possible slider orientations.
-//#[derive(PartialEq)]
-//pub enum SliderOrientation {
-//    /// Indicates a horizontally controllable slider.
-//    SliderHorizontal,
-//
-//    /// Indicates a vertically controllable slider.
-//    SliderVertical,
-//}
+/// This is the callback type that is used when an `on_selected` callback is triggered from this
+/// `Widget`.
+pub type OnSelectedCallbackType =
+Option<Box<dyn FnMut(&mut ListWidget, &[WidgetContainer], &[LayoutContainer], i32)>>;
 
 /// This is the storage object for the `ListWidget`.  It stores the config, properties, callback registry.
 pub struct ListWidget {
@@ -50,13 +41,16 @@ pub struct ListWidget {
     system_properties: HashMap<i32, String>,
     callback_registry: CallbackRegistry,
     list_items: Vec<String>,
+    highlighted_item: i32,
+    selected_item: i32,
+    in_bounds: bool,
+    on_selected: OnSelectedCallbackType,
 }
 
-/// This is the implementation of the `ListWidget`, a control that draws a bounds line indicator, and a
-/// draggable slider.
+/// This is the implementation of the `ListWidget`, a control that displays a list of items that can be
+/// selected.
 impl ListWidget {
-    /// Creates a new `SliderWidget` given the `x, y, w, h` coordinates, sets the `min` and `max` values,
-    /// the `current` value, and the `orientation` of the slider as drawn.
+    /// Creates a new `ListWidget` given the `x, y, w, h` coordinates.
     pub fn new(
         x: i32,
         y: i32,
@@ -68,6 +62,10 @@ impl ListWidget {
             system_properties: HashMap::new(),
             callback_registry: CallbackRegistry::new(),
             list_items: vec![],
+            highlighted_item: -1,
+            selected_item: -1,
+            in_bounds: false,
+            on_selected: None,
         }
     }
 
@@ -80,25 +78,91 @@ impl ListWidget {
         item_size
     }
 
-//    /// Assigns the callback closure that will be used when the `Widget` changes value.
-//    pub fn on_value_changed<F>(&mut self, callback: F)
-//        where
-//            F: FnMut(&mut SliderWidget, &[WidgetContainer], &[LayoutContainer], u32) + 'static,
-//    {
-//        self.on_value_changed = Some(Box::new(callback));
-//    }
-//
-//    /// Internal function that triggers the `on_value_changed` callback.
-//    fn call_value_changed_callback(
-//        &mut self,
-//        widgets: &[WidgetContainer],
-//        layouts: &[LayoutContainer],
-//    ) {
-//        if let Some(mut cb) = self.on_value_changed.take() {
-//            cb(self, widgets, layouts, self.current);
-//            self.on_value_changed = Some(cb);
-//        }
-//    }
+    fn draw_text(&mut self, c: &mut Canvas<Window>, msg: String, x: u32, y: u32, back_color: Color, text_color: Color) {
+        let base_color = back_color;
+        let text_max_width =
+            self.get_size(CONFIG_SIZE)[0] - ((self.get_numeric(CONFIG_BORDER_WIDTH) * 2) as u32);
+
+        let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string()).unwrap();
+        let texture_creator = c.texture_creator();
+        let mut font = ttf_context
+            .load_font(Path::new(&String::from("assets/OpenSans-Regular.ttf")), 16 as u16)
+            .unwrap();
+
+        font.set_style(sdl2::ttf::FontStyle::NORMAL);
+
+        let surface = font
+            .render(&msg)
+            .blended_wrapped(text_color, text_max_width)
+            .map_err(|e| e.to_string())
+            .unwrap();
+        let texture = texture_creator
+            .create_texture_from_surface(&surface)
+            .map_err(|e| e.to_string())
+            .unwrap();
+
+        let TextureQuery { width, height, .. } = texture.query();
+
+        let texture_y = self.get_config().to_y(y as i32);
+        let widget_w = self.get_size(CONFIG_SIZE)[0] as i32;
+        let texture_x = self.get_config().to_x(10);
+
+        c.set_draw_color(back_color);
+        c.fill_rect(Rect::new(self.get_config().to_x(x as i32),
+        self.get_config().to_y(y as i32),
+                              self.get_size(CONFIG_SIZE)[0],
+        30)).unwrap();
+
+        c.copy(
+            &texture,
+            None,
+            Rect::new(texture_x, texture_y, width, height),
+        )
+            .unwrap();
+    }
+
+    fn draw_list(&mut self, c: &mut Canvas<Window>) {
+        let list_size = self.list_items.len();
+        let list_height: u32 = 30;
+
+        for i in 0..list_size {
+            let mut text_color = Color::RGB(0, 0, 0);
+            let mut color = if self.highlighted_item == i as i32 {
+                self.get_color(CONFIG_COLOR_HOVER)
+            } else {
+                Color::RGB(255, 255, 255)
+            };
+
+            if self.selected_item == i as i32 {
+                color = Color::RGB(0, 0, 0);
+                text_color = Color::RGB(255, 255, 255);
+            }
+
+            self.draw_text(c, self.list_items[i].clone(), 0, list_height * i as u32 as u32,
+                           color, text_color);
+        }
+    }
+
+    /// Assigns the callback closure that will be used when the `Widget` changes value, based on a selected
+    /// item.
+    pub fn on_selected<F>(&mut self, callback: F)
+        where
+            F: FnMut(&mut ListWidget, &[WidgetContainer], &[LayoutContainer], i32) + 'static,
+    {
+        self.on_selected = Some(Box::new(callback));
+    }
+
+    /// Internal function that triggers the `on_selected` callback.
+    fn call_selected_callback(
+        &mut self,
+        widgets: &[WidgetContainer],
+        layouts: &[LayoutContainer],
+    ) {
+        if let Some(mut cb) = self.on_selected.take() {
+            cb(self, widgets, layouts, self.selected_item);
+            self.on_selected = Some(cb);
+        }
+    }
 }
 
 /// This is the `Widget` implementation of the `ListWidget`.
@@ -109,6 +173,8 @@ impl Widget for ListWidget {
 
         c.set_draw_color(base_color);
         c.fill_rect(self.get_drawing_area()).unwrap();
+
+        self.draw_list(c);
 
         let border_color = self.get_config().get_color(CONFIG_COLOR_BORDER);
 
@@ -125,166 +191,18 @@ impl Widget for ListWidget {
                     .unwrap();
             }
         }
-
-//        if self.orientation == SliderHorizontal {
-//            let base_color = self.get_color(CONFIG_COLOR_BASE);
-//
-//            c.set_draw_color(base_color);
-//            c.fill_rect(self.get_drawing_area()).unwrap();
-//
-//            // Draw base - three lines in the center
-//            let half_height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT] / 2) as i32;
-//            let width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH]) as i32;
-//
-//            c.set_draw_color(Color::RGB(192, 192, 192));
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(0),
-//                    self.get_config().to_y(half_height),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(width),
-//                    self.get_config().to_y(half_height),
-//                ),
-//            )
-//                .unwrap();
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(0),
-//                    self.get_config().to_y(half_height - 1),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(width),
-//                    self.get_config().to_y(half_height - 1),
-//                ),
-//            )
-//                .unwrap();
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(0),
-//                    self.get_config().to_y(half_height + 1),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(width),
-//                    self.get_config().to_y(half_height + 1),
-//                ),
-//            )
-//                .unwrap();
-//
-//            // Draw slider at current value
-//            let full_range = self.max - self.min;
-//            let slider_center =
-//                ((width as f64 / full_range as f64) * (self.current - self.min) as f64) as u32;
-//            let slider_start = if slider_center >= width as u32 - 15 {
-//                width as u32 - 30
-//            } else if slider_center <= 15 {
-//                0
-//            } else {
-//                slider_center - 15
-//            };
-//
-//            c.set_draw_color(base_color);
-//            c.fill_rect(Rect::new(
-//                self.get_config().to_x(slider_start as i32),
-//                self.get_config().to_y(0),
-//                30,
-//                self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT],
-//            ))
-//                .unwrap();
-//
-//            c.set_draw_color(Color::RGB(0, 0, 0));
-//            c.draw_rect(Rect::new(
-//                self.get_config().to_x(slider_start as i32),
-//                self.get_config().to_y(0),
-//                30,
-//                self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT],
-//            ))
-//                .unwrap();
-//        } else if self.orientation == SliderVertical {
-//            let base_color = self.get_color(CONFIG_COLOR_BASE);
-//
-//            c.set_draw_color(base_color);
-//            c.fill_rect(self.get_drawing_area()).unwrap();
-//
-//            // Draw base - three lines in the center
-//            let half_width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH] / 2) as i32;
-//            let height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT]) as i32;
-//
-//            c.set_draw_color(Color::RGB(192, 192, 192));
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(half_width),
-//                    self.get_config().to_y(0),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(half_width),
-//                    self.get_config().to_y(height),
-//                ),
-//            )
-//                .unwrap();
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(half_width - 1),
-//                    self.get_config().to_y(0),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(half_width - 1),
-//                    self.get_config().to_y(height),
-//                ),
-//            )
-//                .unwrap();
-//            c.draw_line(
-//                Point::new(
-//                    self.get_config().to_x(half_width + 1),
-//                    self.get_config().to_y(0),
-//                ),
-//                Point::new(
-//                    self.get_config().to_x(half_width + 1),
-//                    self.get_config().to_y(height),
-//                ),
-//            )
-//                .unwrap();
-//
-//            // Draw slider at current value
-//            let full_range = self.max - self.min;
-//            let slider_center =
-//                ((height as f64 / full_range as f64) * (self.current - self.min) as f64) as u32;
-//            let slider_start = if slider_center >= height as u32 - 15 {
-//                height as u32 - 30
-//            } else if slider_center <= 15 {
-//                0
-//            } else {
-//                slider_center - 15
-//            };
-//
-//            c.set_draw_color(base_color);
-//            c.fill_rect(Rect::new(
-//                self.get_config().to_x(0),
-//                self.get_config().to_y(slider_start as i32),
-//                self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH],
-//                30,
-//            ))
-//                .unwrap();
-//
-//            c.set_draw_color(Color::RGB(0, 0, 0));
-//            c.draw_rect(Rect::new(
-//                self.get_config().to_x(0),
-//                self.get_config().to_y(slider_start as i32),
-//                self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH],
-//                30,
-//            ))
-//                .unwrap();
-//        }
     }
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.
     fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
-//        self.in_bounds = true;
+        self.in_bounds = true;
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.
     fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
-//        self.in_bounds = false;
+        self.in_bounds = false;
+        self.highlighted_item = -1;
+        self.get_config().set_invalidated(true);
     }
 
     /// When a mouse is moved in the bounds of this `Widget`, this function is triggered.
@@ -294,60 +212,21 @@ impl Widget for ListWidget {
         _layouts: &[LayoutContainer],
         points: Points,
     ) {
-//        if self.in_bounds && self.active && self.originated {
-//            if self.orientation == SliderHorizontal {
-//                let width = (self.get_config().get_size(CONFIG_SIZE)[SIZE_WIDTH]) as i32;
-//                let position_x =
-//                    points[POINT_X] - self.get_config().get_point(CONFIG_ORIGIN)[POINT_X] as i32;
-//                let percentage = position_x as f64 / width as f64;
-//                let full_range = self.max - self.min;
-//                let actual = (percentage * full_range as f64) as u32;
-//
-//                self.current = self.min + actual;
-//
-//                self.get_config().set_invalidated(true);
-//                self.call_value_changed_callback(_widgets, _layouts);
-//            } else if self.orientation == SliderVertical {
-//                let height = (self.get_config().get_size(CONFIG_SIZE)[SIZE_HEIGHT]) as i32;
-//                let position_y =
-//                    points[POINT_Y] - self.get_config().get_point(CONFIG_ORIGIN)[POINT_Y] as i32;
-//                let percentage = position_y as f64 / height as f64;
-//                let full_range = self.max - self.min;
-//                let actual = (percentage * full_range as f64) as u32;
-//
-//                self.current = self.min + actual;
-//
-//                self.get_config().set_invalidated(true);
-//                self.call_value_changed_callback(_widgets, _layouts);
-//            }
-//        }
-    }
+        if self.in_bounds {
+            let position_y =
+                points[POINT_Y] - self.get_config().get_point(CONFIG_ORIGIN)[POINT_Y] as i32;
+            let previous_highlighted_item = self.highlighted_item;
 
-    /// Handles the scrolling functionality.
-    fn mouse_scrolled(
-        &mut self,
-        _widgets: &[WidgetContainer],
-        _layouts: &[LayoutContainer],
-        points: Points,
-    ) {
-//        let mut current_i32 = self.current as i32;
-//
-//        if self.orientation == SliderHorizontal {
-//            current_i32 += points[POINT_X];
-//        } else if self.orientation == SliderVertical {
-//            current_i32 += -points[POINT_Y];
-//        }
-//
-//        if current_i32 >= self.max as i32 {
-//            current_i32 = self.max as i32;
-//        } else if current_i32 <= self.min as i32 {
-//            current_i32 = self.min as i32;
-//        }
-//
-//        self.current = current_i32 as u32;
-//
-//        self.get_config().set_invalidated(true);
-//        self.call_value_changed_callback(_widgets, _layouts);
+            self.highlighted_item = position_y / 30;
+
+            if self.highlighted_item >= self.list_items.len() as i32 {
+                self.highlighted_item = -1;
+            }
+
+            if self.highlighted_item != previous_highlighted_item {
+                self.get_config().set_invalidated(true);
+            }
+        }
     }
 
     /// Overrides the `button_clicked` callback to handle toggling.
@@ -355,23 +234,16 @@ impl Widget for ListWidget {
         &mut self,
         _widgets: &[WidgetContainer],
         _layouts: &[LayoutContainer],
-        _button: u8,
+        button: u8,
         _clicks: u8,
-        _state: bool,
+        state: bool,
     ) {
-//        if _button == 1 {
-//            if _state {
-//                self.active = true;
-//                self.originated = true;
-//            } else {
-//                self.active = false;
-//                self.originated = false;
-//            }
-//
-//            self.get_config().set_invalidated(true);
-//        }
-//
-//        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
+        if button == 1 && state {
+            self.selected_item = self.highlighted_item;
+            self.get_config().set_invalidated(true);
+
+            self.call_selected_callback(_widgets, _layouts);
+        }
     }
 
     default_widget_functions!();

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -52,3 +52,6 @@ pub mod slider_widget;
 /// This is a `GridWidget` that contains a number of `Widget`s that can be repositioned and snapped to
 /// a grid coordinate.
 pub mod grid_widget;
+
+/// This is a `ListWidget` that displays a list of items in a selectable box.
+pub mod list_widget;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -55,3 +55,8 @@ pub mod grid_widget;
 
 /// This is a `ListWidget` that displays a list of items in a selectable box.
 pub mod list_widget;
+
+/// This is a `TileWidget` that displays an image and some text below it, with a display change when
+/// the widget is hovered over by a mouse enter event.  This is mainly used in conjunction with the
+/// `ToolbarWidget`, which contains a list of `TileWidget`s
+pub mod tile_widget;

--- a/src/widgets/tile_widget.rs
+++ b/src/widgets/tile_widget.rs
@@ -23,10 +23,6 @@ use sdl2::render::Canvas;
 use sdl2::video::Window;
 
 use crate::render::layout_cache::LayoutContainer;
-use crate::render::widget_config::CompassPosition::Center;
-use crate::widgets::image_widget::ImageWidget;
-use crate::widgets::text_widget::{TextJustify, TextWidget};
-use sdl2::pixels::Color;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -40,13 +36,13 @@ pub struct TileWidget {
     config: WidgetConfig,
     system_properties: HashMap<i32, String>,
     callback_registry: CallbackRegistry,
-//    base_widget: BaseWidget,
-//    text_widget: TextWidget,
-//    image_widget: ImageWidget,
-//    active: bool,
-//    in_bounds: bool,
-//    originated: bool,
-//    on_click: OnClickCallbackType,
+    //    base_widget: BaseWidget,
+    //    text_widget: TextWidget,
+    //    image_widget: ImageWidget,
+    //    active: bool,
+    //    in_bounds: bool,
+    //    originated: bool,
+    //    on_click: OnClickCallbackType,
 }
 
 /// This is the implementation of the `TileWidget`, which displays an image next to some text.
@@ -58,109 +54,109 @@ impl TileWidget {
         y: i32,
         w: u32,
         h: u32,
-//        text: String,
-//        font_size: i32,
-//        image_name: String,
+        //        text: String,
+        //        font_size: i32,
+        //        image_name: String,
     ) -> Self {
-//        let mut base_widget = BaseWidget::new(x, y, w, h);
-//        let mut text_widget = TextWidget::new(
-//            String::from("assets/OpenSans-Regular.ttf"),
-//            sdl2::ttf::FontStyle::NORMAL,
-//            font_size,
-//            TextJustify::Left,
-//            text.clone(),
-//            x + h as i32 + 6,
-//            y + 2,
-//            w - h - 10,
-//            h - 4,
-//        );
-//        let mut image_widget = ImageWidget::new(image_name, x + 2, y + 2, h - 4, h - 4, false);
-//
-//        base_widget.set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
-//        text_widget.set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
-//        image_widget.set_compass(CONFIG_IMAGE_POSITION, Center);
+        //        let mut base_widget = BaseWidget::new(x, y, w, h);
+        //        let mut text_widget = TextWidget::new(
+        //            String::from("assets/OpenSans-Regular.ttf"),
+        //            sdl2::ttf::FontStyle::NORMAL,
+        //            font_size,
+        //            TextJustify::Left,
+        //            text.clone(),
+        //            x + h as i32 + 6,
+        //            y + 2,
+        //            w - h - 10,
+        //            h - 4,
+        //        );
+        //        let mut image_widget = ImageWidget::new(image_name, x + 2, y + 2, h - 4, h - 4, false);
+        //
+        //        base_widget.set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+        //        text_widget.set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
+        //        image_widget.set_compass(CONFIG_IMAGE_POSITION, Center);
 
         Self {
             config: WidgetConfig::new(x, y, w, h),
             system_properties: HashMap::new(),
             callback_registry: CallbackRegistry::new(),
-//            base_widget,
-//            text_widget,
-//            image_widget,
-//            active: false,
-//            in_bounds: false,
-//            originated: false,
-//            on_click: None,
+            //            base_widget,
+            //            text_widget,
+            //            image_widget,
+            //            active: false,
+            //            in_bounds: false,
+            //            originated: false,
+            //            on_click: None,
         }
     }
 
-    fn draw_hovered(&mut self) {
-//        self.base_widget
-//            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
-//        self.text_widget
-//            .set_color(CONFIG_COLOR_TEXT, Color::RGB(255, 255, 255));
-//        self.text_widget
-//            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
-//        self.get_config().set_invalidated(true);
-    }
+    //    fn draw_hovered(&mut self) {
+    //        self.base_widget
+    //            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
+    //        self.text_widget
+    //            .set_color(CONFIG_COLOR_TEXT, Color::RGB(255, 255, 255));
+    //        self.text_widget
+    //            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
+    //        self.get_config().set_invalidated(true);
+    //    }
+    //
+    //    fn draw_unhovered(&mut self) {
+    //        self.base_widget
+    //            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+    //        self.text_widget
+    //            .set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
+    //        self.text_widget
+    //            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+    //        self.get_config().set_invalidated(true);
+    //    }
 
-    fn draw_unhovered(&mut self) {
-//        self.base_widget
-//            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
-//        self.text_widget
-//            .set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
-//        self.text_widget
-//            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
-//        self.get_config().set_invalidated(true);
-    }
-
-//    /// Assigns the callback closure that will be used when a button click is triggered.
-//    pub fn on_click<F>(&mut self, callback: F)
-//        where
-//            F: FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer]) + 'static,
-//    {
-//        self.on_click = Some(Box::new(callback));
-//    }
-//
-//    /// Internal function that triggers the `on_click` callback.
-//    fn call_click_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
-//        if let Some(mut cb) = self.on_click.take() {
-//            cb(self, widgets, layouts);
-//            self.on_click = Some(cb);
-//        }
-//    }
+    //    /// Assigns the callback closure that will be used when a button click is triggered.
+    //    pub fn on_click<F>(&mut self, callback: F)
+    //        where
+    //            F: FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer]) + 'static,
+    //    {
+    //        self.on_click = Some(Box::new(callback));
+    //    }
+    //
+    //    /// Internal function that triggers the `on_click` callback.
+    //    fn call_click_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
+    //        if let Some(mut cb) = self.on_click.take() {
+    //            cb(self, widgets, layouts);
+    //            self.on_click = Some(cb);
+    //        }
+    //    }
 }
 
 /// This is the `Widget` implementation of the `TileWidget`.
 impl Widget for TileWidget {
-    fn draw(&mut self, c: &mut Canvas<Window>) {
-//        // Paint the base widget first.  Forcing a draw() call here will ignore invalidation.
-//        // Invalidation is controlled by the top level widget (this box).
-//        self.base_widget.draw(c);
-//        self.text_widget.draw(c);
-//        self.image_widget.draw(c);
+    fn draw(&mut self, _c: &mut Canvas<Window>) {
+        //        // Paint the base widget first.  Forcing a draw() call here will ignore invalidation.
+        //        // Invalidation is controlled by the top level widget (this box).
+        //        self.base_widget.draw(c);
+        //        self.text_widget.draw(c);
+        //        self.image_widget.draw(c);
     }
 
     /// When a mouse enters the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
     fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
-//        if self.active {
-//            self.draw_hovered();
-//        }
-//
-//        self.in_bounds = true;
-//        self.mouse_entered_callback(_widgets, _layouts);
+        //        if self.active {
+        //            self.draw_hovered();
+        //        }
+        //
+        //        self.in_bounds = true;
+        //        self.mouse_entered_callback(_widgets, _layouts);
     }
 
     /// When a mouse exits the bounds of the `Widget`, this function is triggered.  This function
     /// implementation is **optional**.
     fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
-//        if self.active {
-//            self.draw_unhovered();
-//        }
-//
-//        self.in_bounds = false;
-//        self.mouse_exited_callback(_widgets, _layouts);
+        //        if self.active {
+        //            self.draw_unhovered();
+        //        }
+        //
+        //        self.in_bounds = false;
+        //        self.mouse_exited_callback(_widgets, _layouts);
     }
 
     fn button_clicked(
@@ -171,28 +167,28 @@ impl Widget for TileWidget {
         _clicks: u8,
         _state: bool,
     ) {
-//        if _button == 1 {
-//            if _state {
-//                self.draw_hovered();
-//                self.active = true;
-//                self.originated = true;
-//            } else {
-//                let had_bounds = self.active;
-//
-//                self.draw_unhovered();
-//                self.active = false;
-//
-//                if self.in_bounds && had_bounds && self.originated {
-//                    // Callback here
-//                    eprintln!("Call callback here: clicks={}", _clicks);
-//                    self.call_click_callback(_widgets, _layouts);
-//                }
-//
-//                self.originated = false;
-//            }
-//        }
-//
-//        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
+        //        if _button == 1 {
+        //            if _state {
+        //                self.draw_hovered();
+        //                self.active = true;
+        //                self.originated = true;
+        //            } else {
+        //                let had_bounds = self.active;
+        //
+        //                self.draw_unhovered();
+        //                self.active = false;
+        //
+        //                if self.in_bounds && had_bounds && self.originated {
+        //                    // Callback here
+        //                    eprintln!("Call callback here: clicks={}", _clicks);
+        //                    self.call_click_callback(_widgets, _layouts);
+        //                }
+        //
+        //                self.originated = false;
+        //            }
+        //        }
+        //
+        //        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
     }
 
     default_widget_functions!();

--- a/src/widgets/tile_widget.rs
+++ b/src/widgets/tile_widget.rs
@@ -1,0 +1,201 @@
+// Pushrod Widget Library
+// Tile Widget
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::render::callbacks::CallbackRegistry;
+use crate::render::widget::*;
+use crate::render::widget_cache::WidgetContainer;
+use crate::render::widget_config::*;
+use crate::render::Points;
+
+use sdl2::render::Canvas;
+use sdl2::video::Window;
+
+use crate::render::layout_cache::LayoutContainer;
+use crate::render::widget_config::CompassPosition::Center;
+use crate::widgets::image_widget::ImageWidget;
+use crate::widgets::text_widget::{TextJustify, TextWidget};
+use sdl2::pixels::Color;
+use std::any::Any;
+use std::collections::HashMap;
+
+/// This is the callback type that is used when an `on_click` callback is triggered from this
+/// `Widget`.
+//pub type OnClickCallbackType =
+//Option<Box<dyn FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer])>>;
+
+/// This is the storage object for the `TileWidget`.  It stores the config, properties, callback registry.
+pub struct TileWidget {
+    config: WidgetConfig,
+    system_properties: HashMap<i32, String>,
+    callback_registry: CallbackRegistry,
+//    base_widget: BaseWidget,
+//    text_widget: TextWidget,
+//    image_widget: ImageWidget,
+//    active: bool,
+//    in_bounds: bool,
+//    originated: bool,
+//    on_click: OnClickCallbackType,
+}
+
+/// This is the implementation of the `TileWidget`, which displays an image next to some text.
+impl TileWidget {
+    /// Creates a new `TileWidget`, given the `x, y, w, h` coordinates, a block of `text`, the
+    /// `font_size` to use, and the `image_name` to load and display.
+    pub fn new(
+        x: i32,
+        y: i32,
+        w: u32,
+        h: u32,
+//        text: String,
+//        font_size: i32,
+//        image_name: String,
+    ) -> Self {
+//        let mut base_widget = BaseWidget::new(x, y, w, h);
+//        let mut text_widget = TextWidget::new(
+//            String::from("assets/OpenSans-Regular.ttf"),
+//            sdl2::ttf::FontStyle::NORMAL,
+//            font_size,
+//            TextJustify::Left,
+//            text.clone(),
+//            x + h as i32 + 6,
+//            y + 2,
+//            w - h - 10,
+//            h - 4,
+//        );
+//        let mut image_widget = ImageWidget::new(image_name, x + 2, y + 2, h - 4, h - 4, false);
+//
+//        base_widget.set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+//        text_widget.set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
+//        image_widget.set_compass(CONFIG_IMAGE_POSITION, Center);
+
+        Self {
+            config: WidgetConfig::new(x, y, w, h),
+            system_properties: HashMap::new(),
+            callback_registry: CallbackRegistry::new(),
+//            base_widget,
+//            text_widget,
+//            image_widget,
+//            active: false,
+//            in_bounds: false,
+//            originated: false,
+//            on_click: None,
+        }
+    }
+
+    fn draw_hovered(&mut self) {
+//        self.base_widget
+//            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
+//        self.text_widget
+//            .set_color(CONFIG_COLOR_TEXT, Color::RGB(255, 255, 255));
+//        self.text_widget
+//            .set_color(CONFIG_COLOR_BASE, Color::RGB(0, 0, 0));
+//        self.get_config().set_invalidated(true);
+    }
+
+    fn draw_unhovered(&mut self) {
+//        self.base_widget
+//            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+//        self.text_widget
+//            .set_color(CONFIG_COLOR_TEXT, Color::RGB(0, 0, 0));
+//        self.text_widget
+//            .set_color(CONFIG_COLOR_BASE, Color::RGB(255, 255, 255));
+//        self.get_config().set_invalidated(true);
+    }
+
+//    /// Assigns the callback closure that will be used when a button click is triggered.
+//    pub fn on_click<F>(&mut self, callback: F)
+//        where
+//            F: FnMut(&mut ImageButtonWidget, &[WidgetContainer], &[LayoutContainer]) + 'static,
+//    {
+//        self.on_click = Some(Box::new(callback));
+//    }
+//
+//    /// Internal function that triggers the `on_click` callback.
+//    fn call_click_callback(&mut self, widgets: &[WidgetContainer], layouts: &[LayoutContainer]) {
+//        if let Some(mut cb) = self.on_click.take() {
+//            cb(self, widgets, layouts);
+//            self.on_click = Some(cb);
+//        }
+//    }
+}
+
+/// This is the `Widget` implementation of the `TileWidget`.
+impl Widget for TileWidget {
+    fn draw(&mut self, c: &mut Canvas<Window>) {
+//        // Paint the base widget first.  Forcing a draw() call here will ignore invalidation.
+//        // Invalidation is controlled by the top level widget (this box).
+//        self.base_widget.draw(c);
+//        self.text_widget.draw(c);
+//        self.image_widget.draw(c);
+    }
+
+    /// When a mouse enters the bounds of the `Widget`, this function is triggered.  This function
+    /// implementation is **optional**.
+    fn mouse_entered(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+//        if self.active {
+//            self.draw_hovered();
+//        }
+//
+//        self.in_bounds = true;
+//        self.mouse_entered_callback(_widgets, _layouts);
+    }
+
+    /// When a mouse exits the bounds of the `Widget`, this function is triggered.  This function
+    /// implementation is **optional**.
+    fn mouse_exited(&mut self, _widgets: &[WidgetContainer], _layouts: &[LayoutContainer]) {
+//        if self.active {
+//            self.draw_unhovered();
+//        }
+//
+//        self.in_bounds = false;
+//        self.mouse_exited_callback(_widgets, _layouts);
+    }
+
+    fn button_clicked(
+        &mut self,
+        _widgets: &[WidgetContainer],
+        _layouts: &[LayoutContainer],
+        _button: u8,
+        _clicks: u8,
+        _state: bool,
+    ) {
+//        if _button == 1 {
+//            if _state {
+//                self.draw_hovered();
+//                self.active = true;
+//                self.originated = true;
+//            } else {
+//                let had_bounds = self.active;
+//
+//                self.draw_unhovered();
+//                self.active = false;
+//
+//                if self.in_bounds && had_bounds && self.originated {
+//                    // Callback here
+//                    eprintln!("Call callback here: clicks={}", _clicks);
+//                    self.call_click_callback(_widgets, _layouts);
+//                }
+//
+//                self.originated = false;
+//            }
+//        }
+//
+//        self.button_clicked_callback(_widgets, _layouts, _button, _clicks, _state);
+    }
+
+    default_widget_functions!();
+    default_widget_properties!();
+    default_widget_callbacks!();
+}


### PR DESCRIPTION
- Sample applications cleanup
- Added `fps` to `engine::new`, which enables CPU throttling for app as appropriate
- Modified engine `run` loop to measure time flux for CPU and implements thread sleep as appropriate (#259)
- Modified `grid` example so that the minimum is 1, not 0 (step cannot be 0 in the grid)
- Updated documentation to fix `Engine::new` definition (#260)
- Changed `fps` to `frame_rate` in `Engine::new`
- Added `ListWidget` (#255), added `list` app to show use
- Added `append_widget()` to `Layout` trait (#261) - suggested by @jbethune
- Updated `layout` to use append_widget layout method.